### PR TITLE
IEEE Std. 1685-2022

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-
+```
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,3 +175,4 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+```

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,11 @@
+=========================================================================
+==  NOTICE file corresponding to section 4 d of the Apache License,    ==
+==  Version 2.0, in this case for the IP-XACT XML Schema Definition,   ==
+==  the XSL Transformations, the TGI WDSL and YAML descriptions, and   ==
+==  the XML document examples                                          ==
+=========================================================================
+
+This product includes software developed by Accellera Systems Initiative
+8698 Elk Grove Bldv Suite 1, #114, Elk Grove, CA 95624, USA
+Copyright 2011-2023 Accellera Systems Initiative Inc. (Accellera)
+All rights reserved.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,4 @@
+```
 =========================================================================
 ==  NOTICE file corresponding to section 4 d of the Apache License,    ==
 ==  Version 2.0, in this case for the IP-XACT XML Schema Definition,   ==
@@ -9,3 +10,4 @@ This product includes software developed by Accellera Systems Initiative
 8698 Elk Grove Bldv Suite 1, #114, Elk Grove, CA 95624, USA
 Copyright 2011-2023 Accellera Systems Initiative Inc. (Accellera)
 All rights reserved.
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,47 @@
-This repository holds all IP-XACT schema files for
+This repository holds all XML Schema Definition (XSD) files for various IP-XACT releases. 
 
-* Unknown license / non OSI approved license
-  * [IP-XACT 1.0](http://www.accellera.org/XMLSchema/SPIRIT/1.0/)
-  * [IP-XACT 1.1](http://www.accellera.org/XMLSchema/SPIRIT/1.1/)
-  * [IP-XACT 1.2](http://www.accellera.org/XMLSchema/SPIRIT/1.2/)
-  * [IP-XACT 1.4](http://www.accellera.org/XMLSchema/SPIRIT/1.4/)
-  * [IP-XACT 1.5](http://www.accellera.org/XMLSchema/SPIRIT/1.5/)
-  * [IEEE Std. 1685-2009](http://www.accellera.org/XMLSchema/SPIRIT/1685-2009/)
-* [Apache License, Version 2.0](http://www.accellera.org/XMLSchema/IPXACT/LICENSE) / [Notice](http://www.accellera.org/XMLSchema/IPXACT/NOTICE) 
-  * [IEEE Std. 1685-2014](http://www.accellera.org/XMLSchema/IPXACT/1685-2014/)  
-    ⚠️ local README (provided by Accellera) contains open source threatening rules ⚠️
-  * [IEEE Std. 1685-2022](http://www.accellera.org/XMLSchema/IPXACT/1685-2022/)  
-    ⚠️ local README (provided by Accellera) contains open source threatening rules ⚠️
+# SPIRIT Consortium
+
+The Structure for Packaging, Integrating and Re-using IP within Tool-flows (SPIRIT) consortium was created to develop a
+standard for more efficient integration of IP in System-on-Chip (SoC) platform design in two areas: IP meta-data
+description and a tool integration API.
+
+SPIRIT Version 1.0 was released on December 8th, 2004 and addressed SoC design at the RT level. Work had already started
+to draft Version 2.0 of the standard that was to extend the specification to cover comprehensive interoperability
+between tools and explicit support of Electronic System Level (ESL) Design and Verification.
+
+Around the time of DAC 2005, the IEEE P1685 working group was formed.
+
+## Unknown license state
+
+* [IP-XACT 1.0](http://www.accellera.org/XMLSchema/SPIRIT/1.0/)
+* [IP-XACT 1.1](http://www.accellera.org/XMLSchema/SPIRIT/1.1/)
+* [IP-XACT 1.2](http://www.accellera.org/XMLSchema/SPIRIT/1.2/)
+* [IP-XACT 1.4](http://www.accellera.org/XMLSchema/SPIRIT/1.4/)
+* [IP-XACT 1.5](http://www.accellera.org/XMLSchema/SPIRIT/1.5/)
+
+# IEEE Std. 1685-20xx
+
+## Unknown license state
+
+* [IEEE Std. 1685-2009](http://www.accellera.org/XMLSchema/SPIRIT/1685-2009/)
+ 
+## Apache License, Version 2.0
+
+License: [Apache License, Version 2.0](http://www.accellera.org/XMLSchema/IPXACT/LICENSE)  
+Notices: [Notice](http://www.accellera.org/XMLSchema/IPXACT/NOTICE)
+
+* [IEEE Std. 1685-2014](http://www.accellera.org/XMLSchema/IPXACT/1685-2014/)  
+  ⚠️ local README (provided by Accellera) contains open source threatening rules ⚠️
+* [IEEE Std. 1685-2022](http://www.accellera.org/XMLSchema/IPXACT/1685-2022/)  
+  ⚠️ local README (provided by Accellera) contains open source threatening rules ⚠️
 
 
 From the Accellera page
 -----------------------
+
+> The following rules provided by *Accellera Systems Initiative* are contradicting the Apache License, which e.g. allows
+> to create derived and modified work.
 
 © Copyright Accellera Systems Initiative. All rights reserved.
 
@@ -48,6 +74,11 @@ the schema. The intended and allowed uses of the schema include:
   provide for validation of elements and attributes at the extension points explicitly and implicitly included in the
   IEEE 1685-2022 standard.
 * No right to create new schemas derived from parts of this base schema is granted pursuant to this License.
+
+
+# Further Links:
+
+* [Accellera](https://www.accellera.org/)
 
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ the schema. The intended and allowed uses of the schema include:
   provide for validation of elements and attributes at the extension points explicitly and implicitly included in the
   IEEE 1685-2022 standard.
 * No right to create new schemas derived from parts of this base schema is granted pursuant to this License.
+
+-------------------------
+
+SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository holds all IP-XACT schema files for
 * IP-XACT 1.2
 * IP-XACT 1.4
 * IP-XACT 1.5
-* IEEE 1685-2009
-* IEEE 1685-2014
-* IEEE 1685-2022
+* IEEE Std. 1685-2009
+* [IEEE Std. 1685-2014](http://www.accellera.org/XMLSchema/IPXACT/1685-2014/)
+* [IEEE Std. 1685-2022](http://www.accellera.org/XMLSchema/IPXACT/1685-2022/)
 
 
 From the Accellera page
@@ -19,7 +19,7 @@ the IEEE Std 1685-2022 Standard for IP-XACT, Standard Structure for Packaging, I
 Tool-flows. These files are in the format specified by the World Wide Web Consortium (W3C) as XML Schema definition
 language.
 
-The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std1685-2022
+The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std 1685-2022
 Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows.
 
 **USE AT YOUR OWN RISK**

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 This repository holds all IP-XACT schema files for
-* [IP-XACT 1.0](http://www.accellera.org/XMLSchema/SPIRIT/1.0/)
-* [IP-XACT 1.1](http://www.accellera.org/XMLSchema/SPIRIT/1.1/)
-* [IP-XACT 1.2](http://www.accellera.org/XMLSchema/SPIRIT/1.2/)
-* [IP-XACT 1.4](http://www.accellera.org/XMLSchema/SPIRIT/1.4/)
-* [IP-XACT 1.5](http://www.accellera.org/XMLSchema/SPIRIT/1.5/)
-* [IEEE Std. 1685-2009](http://www.accellera.org/XMLSchema/SPIRIT/1685-2009/)
-* [IEEE Std. 1685-2014](http://www.accellera.org/XMLSchema/IPXACT/1685-2014/)
-* [IEEE Std. 1685-2022](http://www.accellera.org/XMLSchema/IPXACT/1685-2022/)
+
+* Unknown license / non OSI approved license
+  * [IP-XACT 1.0](http://www.accellera.org/XMLSchema/SPIRIT/1.0/)
+  * [IP-XACT 1.1](http://www.accellera.org/XMLSchema/SPIRIT/1.1/)
+  * [IP-XACT 1.2](http://www.accellera.org/XMLSchema/SPIRIT/1.2/)
+  * [IP-XACT 1.4](http://www.accellera.org/XMLSchema/SPIRIT/1.4/)
+  * [IP-XACT 1.5](http://www.accellera.org/XMLSchema/SPIRIT/1.5/)
+  * [IEEE Std. 1685-2009](http://www.accellera.org/XMLSchema/SPIRIT/1685-2009/)
+* [Apache License, Version 2.0](http://www.accellera.org/XMLSchema/IPXACT/LICENSE) / [Notice](http://www.accellera.org/XMLSchema/IPXACT/NOTICE) 
+  * [IEEE Std. 1685-2014](http://www.accellera.org/XMLSchema/IPXACT/1685-2014/)  
+    ⚠️ local README (provided by Accellera) contains open source threatening rules ⚠️
+  * [IEEE Std. 1685-2022](http://www.accellera.org/XMLSchema/IPXACT/1685-2022/)  
+    ⚠️ local README (provided by Accellera) contains open source threatening rules ⚠️
 
 
 From the Accellera page

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 This repository holds all IP-XACT schema files for
-* IP-XACT 1.0
-* IP-XACT 1.1
-* IP-XACT 1.2
-* IP-XACT 1.4
-* IP-XACT 1.5
-* IEEE Std. 1685-2009
+* [IP-XACT 1.0](http://www.accellera.org/XMLSchema/SPIRIT/1.0/)
+* [IP-XACT 1.1](http://www.accellera.org/XMLSchema/SPIRIT/1.1/)
+* [IP-XACT 1.2](http://www.accellera.org/XMLSchema/SPIRIT/1.2/)
+* [IP-XACT 1.4](http://www.accellera.org/XMLSchema/SPIRIT/1.4/)
+* [IP-XACT 1.5](http://www.accellera.org/XMLSchema/SPIRIT/1.5/)
+* [IEEE Std. 1685-2009](http://www.accellera.org/XMLSchema/SPIRIT/1685-2009/)
 * [IEEE Std. 1685-2014](http://www.accellera.org/XMLSchema/IPXACT/1685-2014/)
 * [IEEE Std. 1685-2022](http://www.accellera.org/XMLSchema/IPXACT/1685-2022/)
 

--- a/README.md
+++ b/README.md
@@ -6,29 +6,40 @@ This repository holds all IP-XACT schema files for
 * IP-XACT 1.5
 * IEEE 1685-2009
 * IEEE 1685-2014
+* IEEE 1685-2022
 
 
 From the Accellera page
 -----------------------
 
-© Copyright 2006-2014 Accellera Systems Initiative. All rights reserved.
+© Copyright Accellera Systems Initiative. All rights reserved.
 
-These XML files are believed to be a consistent XML Schema expression for creating and validating XML documents based on the IEEE Std 1685-2009 and 2014 Standards for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows. These files are in the format specified by the World Wide Web Consortium (W3C) as XML Schema definition language.
+These XML files are believed to be a consistent XML Schema expression for creating and validating XML documents based on
+the IEEE Std 1685-2022 Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within
+Tool-flows. These files are in the format specified by the World Wide Web Consortium (W3C) as XML Schema definition
+language.
 
-The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std 1685-2009 and 2014 Standards for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows.
+The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std1685-2022
+Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows.
 
 **USE AT YOUR OWN RISK**
 
-These source files are provided on an AS IS basis. Accellera Systems Initiative disclaims any warranty express or implied including any warranty of merchantability and fitness for use for a particular purpose.
+These source files are provided on an AS IS basis. Accellera Systems Initiative (Accellera) disclaims any warranty
+express or implied including any warranty of merchantability and fitness for use for a particular purpose.
 
-The user of the source files shall indemnify and hold Accellera Systems Initiative and its members harmless from any damages or liability.
+The user of the source files shall indemnify and hold Accellera and its members harmless from any damages or liability.
 
 This file may be copied, and distributed, WITHOUT modifications; this notice must be included on any copy.
 
-This schema shall not be modified, adapted, altered, sublicensed, nor any derivative works shall be created based upon the schema. The intended and allowed uses of the schema include:
+This schema shall not be modified, adapted, altered, sublicensed, nor any derivative works shall be created based upon
+the schema. The intended and allowed uses of the schema include:
 
 * Creating and validating XML documents that conform to the schema
 * Building software programs and systems based on the schema
-* Distributing verbatim copy of the schema as long as the full text of this license is included in all copies of the schema. Specifically, a tool may include full copies of the schema, and these copies may be distributed by the tool provider directly. A link or URL to the original of the schema is inherent in the schema URI.
-* Documents which are validated against this schema may also reference additional schema. These additional schemas may provide for validation of elements and attributes at the extension points explicitly and implicitly included in the IEEE 1685-2009 and 2014 standards.
+* Distributing verbatim copy of the schema as long as the full text of this license is included in all copies of the
+  schema. Specifically, a tool may include full copies of the schema, and these copies may be distributed by the tool
+  provider directly. A link or URL to the original of the schema is inherent in the schema URI.
+* Documents which are validated against this schema may also reference additional schema. These additional schemas may
+  provide for validation of elements and attributes at the extension points explicitly and implicitly included in the
+  IEEE 1685-2022 standard.
 * No right to create new schemas derived from parts of this base schema is granted pursuant to this License.

--- a/ieee-1685-2009/README.md
+++ b/ieee-1685-2009/README.md
@@ -1,0 +1,40 @@
+# IEEE Std. 1685-2009
+
+Source: http://www.accellera.org/XMLSchema/SPIRIT/1685-2009/
+
+
+From the Accellera page
+-----------------------
+
+© Copyright Accellera Systems Initiative. All rights reserved.
+
+These XML files are believed to be a consistent XML Schema expression for creating and validating XML documents based on
+the IEEE Std 1685-2009 Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within
+Tool-flows. These files are in the format specified by the World Wide Web Consortium (W3C) as XML Schema definition
+language.
+
+The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std 1685-2009
+Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows.
+
+**USE AT YOUR OWN RISK**
+
+These source files are provided on an AS IS basis.  Accellera Systems Initiative disclaims any warranty express or
+implied including any warranty of merchantability and fitness for use for a particular purpose.
+
+The user of the source files shall indemnify and hold Accellera Systems Initiative and its members harmless from any
+damages or liability.
+
+This file may be copied, and distributed, WITHOUT modifications; this notice must be included on any copy.
+
+This schema shall not be modified, adapted, altered, sublicensed, nor any derivative works shall be created based upon
+the schema.  The intended and allowed uses of the schema include:
+
+* Creating and validating XML documents that conform to the schema
+* Building software programs and systems based on the schema
+* Distributing verbatim copy of the schema as long as the full text of this license is included in all copies of the
+  schema. Specifically, a tool may include full copies of the schema, and these copies may be distributed by the tool
+  provider directly.  A link or URL to the original of the schema is inherent in the schema URI.
+* Documents which are validated against this schema may also reference additional schema. These additional schemas may
+  provide for validation of elements and attributes at the extension points explicitly and implicitly included in the
+  IEEE 1685-2009 standard.
+* No right to create new schemas derived from parts of this base schema is granted pursuant to this License.

--- a/ieee-1685-2014/README.md
+++ b/ieee-1685-2014/README.md
@@ -1,0 +1,40 @@
+# IEEE Std. 1685-2014
+
+Source: http://www.accellera.org/XMLSchema/IPXACT/1685-2014/
+
+
+From the Accellera page
+-----------------------
+
+© Copyright 2006-2014 Accellera Systems Initiative. All rights reserved.
+
+These XML files are believed to be a consistent XML Schema expression for creating and validating XML documents based on
+the IEEE Std 1685-2009 and 2014 Standards for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP
+within Tool-flows. These files are in the format specified by the World Wide Web Consortium (W3C) as XML Schema
+definition language.
+
+The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std 1685-2009
+and 2014 Standards for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows.
+
+**USE AT YOUR OWN RISK**
+
+These source files are provided on an AS IS basis. Accellera Systems Initiative disclaims any warranty express or
+implied including any warranty of merchantability and fitness for use for a particular purpose.
+
+The user of the source files shall indemnify and hold Accellera Systems Initiative and its members harmless from any
+damages or liability.
+
+This file may be copied, and distributed, WITHOUT modifications; this notice must be included on any copy.
+
+This schema shall not be modified, adapted, altered, sublicensed, nor any derivative works shall be created based upon
+the schema. The intended and allowed uses of the schema include:
+
+* Creating and validating XML documents that conform to the schema
+* Building software programs and systems based on the schema
+* Distributing verbatim copy of the schema as long as the full text of this license is included in all copies of the
+  schema. Specifically, a tool may include full copies of the schema, and these copies may be distributed by the tool 
+  provider directly. A link or URL to the original of the schema is inherent in the schema URI.
+* Documents which are validated against this schema may also reference additional schema. These additional schemas may
+  provide for validation of elements and attributes at the extension points explicitly and implicitly included in the
+  IEEE 1685-2009 and 2014 standards.
+* No right to create new schemas derived from parts of this base schema is granted pursuant to this License.

--- a/ieee-1685-2022/README.md
+++ b/ieee-1685-2022/README.md
@@ -1,0 +1,39 @@
+# IEEE Std. 1685-2022
+
+Source: http://www.accellera.org/XMLSchema/IPXACT/1685-2022/
+
+
+From the Accellera page
+-----------------------
+
+© Copyright Accellera Systems Initiative. All rights reserved.
+
+These XML files are believed to be a consistent XML Schema expression for creating and validating XML documents based on
+the IEEE Std 1685-2022 Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within
+Tool-flows. These files are in the format specified by the World Wide Web Consortium (W3C) as XML Schema definition
+language.
+
+The purpose of this schema is to allow the creation and validation of XML documents conforming to the IEEE Std 1685-2022
+Standard for IP-XACT, Standard Structure for Packaging, Integrating and Re-using IP within Tool-flows.
+
+**USE AT YOUR OWN RISK**
+
+These source files are provided on an AS IS basis. Accellera Systems Initiative (Accellera) disclaims any warranty
+express or implied including any warranty of merchantability and fitness for use for a particular purpose.
+
+The user of the source files shall indemnify and hold Accellera and its members harmless from any damages or liability.
+
+This file may be copied, and distributed, WITHOUT modifications; this notice must be included on any copy.
+
+This schema shall not be modified, adapted, altered, sublicensed, nor any derivative works shall be created based upon
+the schema. The intended and allowed uses of the schema include:
+
+* Creating and validating XML documents that conform to the schema
+* Building software programs and systems based on the schema
+* Distributing verbatim copy of the schema as long as the full text of this license is included in all copies of the
+  schema. Specifically, a tool may include full copies of the schema, and these copies may be distributed by the tool
+  provider directly. A link or URL to the original of the schema is inherent in the schema URI.
+* Documents which are validated against this schema may also reference additional schema. These additional schemas may
+  provide for validation of elements and attributes at the extension points explicitly and implicitly included in the
+  IEEE 1685-2022 standard.
+* No right to create new schemas derived from parts of this base schema is granted pursuant to this License.

--- a/ieee-1685-2022/abstractionDefinition.xsd
+++ b/ieee-1685-2022/abstractionDefinition.xsd
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="port.xsd"/>
+	<xs:include schemaLocation="generator.xsd"/>
+	<xs:include schemaLocation="constraints.xsd"/>
+	<xs:simpleType name="presenceType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="required"/>
+			<xs:enumeration value="illegal"/>
+			<xs:enumeration value="optional"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="direction">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="in"/>
+			<xs:enumeration value="out"/>
+			<xs:enumeration value="inout"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="presence" type="ipxact:presenceType" default="optional">
+		<xs:annotation>
+			<xs:documentation>If this element is present, the
+            existance of the port is controlled by the specified
+            value. valid values are 'illegal', 'required' and
+            'optional'.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:group name="transactionalPort">
+		<xs:annotation>
+			<xs:documentation>Group of elements used in a transactional port.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:presence" minOccurs="0"/>
+			<xs:element name="initiative" default="requires" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the type of access is restricted to the specified value.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="requires"/>
+						<xs:enumeration value="provides"/>
+						<xs:enumeration value="both"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element ref="ipxact:kind" minOccurs="0"/>
+			<xs:element name="busWidth" type="ipxact:unsignedPositiveIntExpression" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the width must match</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:protocol" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the name must match</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="wirePort">
+		<xs:annotation>
+			<xs:documentation>Group of elements used in a wire port.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:presence" minOccurs="0"/>
+			<xs:element name="width" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Number of bits required to represent this port. Absence of this element indicates unconstrained number of bits, i.e. the component will define the number of bits in this port. The logical numbering of the port starts at 0 to width-1.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="ipxact:unsignedPositiveIntExpression">
+							<xs:attribute name="allBits" type="xs:boolean" default="false">
+								<xs:annotation>
+									<xs:documentation>false: mapping is optional, any number of bits can be mapped.
+true: mapping is required  the full width is supposed to be mapped.</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="direction" type="ipxact:direction" default="out" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the direction of this port is restricted to the specified value. The direction is relative to the non-mirrored interface.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="modeConstraints" type="ipxact:abstractionDefPortConstraintsType">
+					<xs:annotation>
+						<xs:documentation>Specifies default constraints for the enclosing wire type port. If the mirroredModeConstraints element is not defined, then these constraints applied to this port when it appears in a 'mode' bus interface or a mirrored-'mode' bus interface. Otherwise they only apply when the port appears in a 'mode' bus interface.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="mirroredModeConstraints" type="ipxact:abstractionDefPortConstraintsType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Specifies default constraints for the enclosing wire type port when it appears in a mirrored-'mode' bus interface. </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:group>
+	<xs:element name="abstractionDefinition">
+		<xs:annotation>
+			<xs:documentation>Define the ports and other information of a particular abstraction of the bus</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:element name="busType" type="ipxact:libraryRefType">
+					<xs:annotation>
+						<xs:documentation>Reference to the busDefinition that this abstractionDefinition implements.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="extends" type="ipxact:libraryRefType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Optional name of abstraction type that this abstraction definition is compatible with. This abstraction definition may change the definitions of ports in the existing abstraction definition and add new ports, the ports in the original abstraction are not deleted but may be marked illegal to disallow their use.
+				This abstraction definition may only extend another abstraction definition if the bus type of this abstraction definition extends the bus type of the extended abstraction definition</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ports">
+					<xs:annotation>
+						<xs:documentation>This is a list of logical ports defined by the bus.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="port" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="logicalName" type="xs:Name">
+											<xs:annotation>
+												<xs:documentation>The assigned name of this port in bus specifications.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element ref="ipxact:displayName" minOccurs="0"/>
+										<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+										<xs:element ref="ipxact:description" minOccurs="0"/>
+										<xs:element name="match" type="xs:boolean" default="false" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>If this element is enabled (true) it is an error if the port is not mapped on both sides of the connection.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:sequence>
+											<xs:choice>
+												<xs:element ref="ipxact:wire"/>
+												<xs:element name="transactional">
+													<xs:annotation>
+														<xs:documentation>A port that carries complex information modeled at a high level of abstraction.</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The type of information this port carries A transactional port can carry both address and data information.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="onSystem" minOccurs="0" maxOccurs="unbounded">
+																<xs:annotation>
+																	<xs:documentation>Defines constraints for this port when present in a system bus interface with a matching group name.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="group" type="xs:Name">
+																			<xs:annotation>
+																				<xs:documentation>Used to group system ports into different groups within a common bus.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:group ref="ipxact:transactionalPort"/>
+																	</xs:sequence>
+																	<xs:attributeGroup ref="ipxact:id.att"/>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="onInitiator" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Defines constraints for this port when present in a initiator bus interface.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:group ref="ipxact:transactionalPort"/>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="onTarget" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Defines constraints for this port when present in a target bus interface.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:group ref="ipxact:transactionalPort"/>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:choice>
+											<xs:element ref="ipxact:packets" minOccurs="0"/>
+										</xs:sequence>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:choices" minOccurs="0"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:assertions" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:key name="busDefPortKey">
+			<xs:selector xpath="ipxact:ports/ipxact:port"/>
+			<xs:field xpath="ipxact:logicalName"/>
+		</xs:key>
+		<xs:keyref name="timingConstraintKeyRef" refer="ipxact:busDefPortKey">
+			<xs:selector xpath=".//ipxact:timingConstraint"/>
+			<xs:field xpath="@clockName"/>
+		</xs:keyref>
+		<xs:unique name="abstractionDefinitionParameterUnique">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:key name="abstractionDefinitionChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:keyref name="abstractionDefinitionChoiceRef" refer="ipxact:abstractionDefinitionChoiceKey">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+	</xs:element>
+	<xs:element name="packets" type="ipxact:portPacketsType"/>
+	<xs:element name="wire">
+		<xs:annotation>
+			<xs:documentation>A port that carries logic or an array of logic values</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The type of information this port carries A wire port can carry both address and data, but may not mix this with a clock or reset</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="onSystem" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Defines constraints for this port when present in a system bus interface with a matching group name.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="group" type="xs:Name">
+								<xs:annotation>
+									<xs:documentation>Used to group system ports into different groups within a common bus.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:group ref="ipxact:wirePort"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="onInitiator" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Defines constraints for this port when present in a initiator bus interface.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:group ref="ipxact:wirePort"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="onTarget" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Defines constraints for this port when present in a target bus interface.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:group ref="ipxact:wirePort"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:choice minOccurs="0">
+					<xs:element name="defaultValue" type="ipxact:unsignedBitVectorExpression">
+						<xs:annotation>
+							<xs:documentation>Indicates the default value for this wire port.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="ipxact:requiresDriver"/>
+				</xs:choice>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/abstractor.xsd
+++ b/ieee-1685-2022/abstractor.xsd
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="busInterface.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="generator.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="model.xsd"/>
+	<xs:include schemaLocation="subInstances.xsd"/>
+	<xs:include schemaLocation="constraints.xsd"/>
+	<xs:complexType name="abstractorType">
+		<xs:annotation>
+			<xs:documentation>Abstractor-specific extension to abstractorType</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:documentNameGroup"/>
+			<xs:element name="abstractorMode">
+				<xs:annotation>
+					<xs:documentation>Define the mode for the interfaces on this abstractor. 
+
+For initiator the first interface connects to the initiator, the second connects to the mirroredInitiator
+
+For target the first interface connects to the mirroredTarget the second connects to the target
+
+For direct the first interface connects to the initiator, the second connects to the target
+
+For system the first interface connects to the system, the second connects to the mirroredSystem. For system the group attribute is required</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="ipxact:abstractorModeType">
+							<xs:attribute name="group" type="xs:Name">
+								<xs:annotation>
+									<xs:documentation>Define the system group if the mode is set to system</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="busType" type="ipxact:libraryRefType">
+				<xs:annotation>
+					<xs:documentation>The bus type of both interfaces. Refers to bus definition using vendor, library, name, version attributes.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="abstractorInterfaces">
+				<xs:annotation>
+					<xs:documentation>The interfaces supported by this abstractor</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="abstractorInterface" type="ipxact:abstractorBusInterfaceType" minOccurs="2" maxOccurs="2">
+							<xs:annotation>
+								<xs:documentation>An abstractor must have exactly 2 Interfaces.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="model" type="ipxact:abstractorModelType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Model information.</xs:documentation>
+				</xs:annotation>
+				<xs:key name="abstractorInstantiationsKey">
+					<xs:selector xpath="./ipxact:instantiations/ipxact:componentInstantiation"/>
+					<xs:field xpath="./ipxact:name"/>
+				</xs:key>
+				<xs:keyref name="abstractorInstantiationsRef" refer="ipxact:abstractorInstantiationsKey">
+					<xs:selector xpath="./ipxact:views/ipxact:view/ipxact:componentInstantiationRef"/>
+					<xs:field xpath="."/>
+				</xs:keyref>
+			</xs:element>
+			<xs:element ref="ipxact:abstractorGenerators" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Generator list is tools-specific.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:choices" minOccurs="0"/>
+			<xs:element ref="ipxact:fileSets" minOccurs="0"/>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:assertions" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="abstractor" type="ipxact:abstractorType">
+		<xs:annotation>
+			<xs:documentation>This is the root element for abstractors</xs:documentation>
+		</xs:annotation>
+		<xs:key name="abstractorInterfaceKey">
+			<xs:selector xpath="ipxact:abstractorInterfaces/ipxact:abstractorInterface"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="abstractorChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="abstractorChoiceRef" refer="ipxact:abstractorChoiceKey">
+			<xs:selector xpath=".//ipxact:*"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+		<xs:key name="abstractorViewKey">
+			<xs:selector xpath="ipxact:model/ipxact:views/ipxact:view"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="abstractorTypeDefViewRef" refer="ipxact:abstractorViewKey">
+			<xs:selector xpath=".//ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="abstractorViewLinkViewRef" refer="ipxact:abstractorViewKey">
+			<xs:selector xpath=".//ipxact:viewLink/ipxact:viewReference"/>
+			<xs:field xpath="@viewRef"/>
+		</xs:keyref>
+		<xs:key name="abstractorFileSetKey">
+			<xs:selector xpath=".//ipxact:fileSet"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="abstractorFileSetRef" refer="ipxact:abstractorFileSetKey">
+			<xs:selector xpath=".//ipxact:fileSetRef"/>
+			<xs:field xpath="ipxact:localName"/>
+		</xs:keyref>
+		<xs:key name="abstractorPortKey">
+			<xs:selector xpath="ipxact:model/ipxact:ports/ipxact:port"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="abstractorportRef" refer="ipxact:abstractorPortKey">
+			<xs:selector xpath="ipxact:abstractorInterfaces/ipxact:abstractorInterface/ipxact:abstractionTypes/ipxact:abstractionType/ipxact:portMaps/ipxact:portMap/ipxact:physicalPort/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:unique name="abstractorParameterUnique">
+			<xs:selector xpath=".//ipxact:parameter | .//ipxact:moduleParameter | .//ipxact:typeParameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:unique name="abstractorFileUnique">
+			<xs:selector xpath=".//ipxact:file"/>
+			<xs:field xpath="@fileId"/>
+		</xs:unique>
+	</xs:element>
+	<xs:simpleType name="abstractorModeType">
+		<xs:annotation>
+			<xs:documentation>Mode for this abstractor</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="initiator"/>
+			<xs:enumeration value="target"/>
+			<xs:enumeration value="direct"/>
+			<xs:enumeration value="system"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/ieee-1685-2022/autoConfigure.xsd
+++ b/ieee-1685-2022/autoConfigure.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:import schemaLocation="xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:simpleType name="formatType">
+		<xs:annotation>
+			<xs:documentation>This is an indication on the format of the value. bit: 1-bit or more (vector) bits unsigned integer, byte: 8-bit signed integer, shortint: 16-bit signed integer, int: 32-bit signed integer, longint: 64-bit signed integer, shortreal: 32-bit signed floating point number, real: 64-bit signed floating point number, string: textual information.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="bit"/>
+			<xs:enumeration value="byte"/>
+			<xs:enumeration value="shortint"/>
+			<xs:enumeration value="int"/>
+			<xs:enumeration value="longint"/>
+			<xs:enumeration value="shortreal"/>
+			<xs:enumeration value="real"/>
+			<xs:enumeration value="string"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="signType">
+		<xs:annotation>
+			<xs:documentation>This is an indication of the signedness of the value.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="signed"/>
+			<xs:enumeration value="unsigned"/>
+		</xs:restriction>
+	</xs:simpleType>
+		<xs:simpleType name="delayValueUnitType">
+		<xs:annotation>
+			<xs:documentation>Indicates legal units for delay values.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="ps"/>
+			<xs:enumeration value="ns"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:attributeGroup name="any.att">
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="id.att">
+		<xs:annotation>
+			<xs:documentation>Contains the xml:id attribute used for annotating elements with a unique identifiers. See http://www.w3.org/TR/xml-id for more information.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute ref="xml:id"/>
+	</xs:attributeGroup>
+	<xs:element name="choices">
+		<xs:annotation>
+			<xs:documentation>Choices used by elements with an attribute ipxact:choiceRef.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="choice" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Non-empty set of legal values for a elements with an attribute ipxact:choiceRef.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="name" type="xs:Name">
+								<xs:annotation>
+									<xs:documentation>Choice key, available for reference by the ipxact:choiceRef attribute.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="enumeration" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>One possible value of ipxact:choice</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="ipxact:complexBaseExpression">
+											<xs:attribute name="text" type="xs:string">
+												<xs:annotation>
+													<xs:documentation>When specified, displayed in place of the ipxact:enumeration value </xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+											<xs:attribute name="help" type="xs:string">
+												<xs:annotation>
+													<xs:documentation>Text that may be displayed if the user requests help about the meaning of an element</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+                      <xs:attributeGroup ref="ipxact:id.att"/>											
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/busDefinition.xsd
+++ b/ieee-1685-2022/busDefinition.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="port.xsd"/>
+	<xs:include schemaLocation="generator.xsd"/>
+	<xs:include schemaLocation="constraints.xsd"/>
+	<xs:group name="portProperties">
+		<xs:sequence>
+			<xs:choice minOccurs="0">
+				<xs:element name="direction" type="ipxact:componentPortDirectionType" default="out"/>
+				<xs:element ref="ipxact:initiative"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:group>
+	<xs:element name="busDefinition">
+		<xs:annotation>
+			<xs:documentation>Defines the structural information associated with a bus type, independent of the abstraction level.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:element name="directConnection" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>This element indicates that a initiator interface may be directly connected to a target interface (under certain conditions) for busses of this type.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="broadcast" type="xs:boolean" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>This element indicates that this bus definition supports 'broadcast' mode. This means that it is legal to make one-to-many interface connections.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="isAddressable" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>If true, indicates that this is an addressable bus.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="extends" type="ipxact:libraryRefType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Optional name of bus type that this bus definition is compatible with. This bus definition may change the definitions in the existing bus definition</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="maxInitiators" type="ipxact:unsignedIntExpression" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Indicates the maximum number of initiators this bus supports.  If this element is not present, the number of initiators allowed is unbounded. </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="maxTargets" type="ipxact:unsignedIntExpression" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Indicates the maximum number of targets this bus supports.  If the element is not present, the number of targets allowed is unbounded.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="systemGroupNames" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Indicates the list of system group names that are defined for this bus definition.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="systemGroupName" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Indicates the name of a system group defined for this bus definition.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="xs:Name">
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:choices" minOccurs="0"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:assertions" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:key name="systemGroupNameKey">
+			<xs:selector xpath="ipxact:systemGroupNames/ipxact:systemGroupName"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:unique name="busDefinitionParameterUnique">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:key name="busDefinitionChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:keyref name="busDefinitionChoiceRef" refer="ipxact:busDefinitionChoiceKey">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/busInterface.xsd
+++ b/ieee-1685-2022/busInterface.xsd
@@ -1,0 +1,591 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="abstractionDefinition.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="memoryMap.xsd"/>
+	<xs:include schemaLocation="port.xsd"/>
+	<xs:include schemaLocation="autoConfigure.xsd"/>
+	<!--
+	<xs:simpleType name="simpleBitSteeringExpression">
+		<xs:annotation>
+			<xs:documentation>Indicates whether bit steering should be used to map this interface onto a bus of different data width.
+            
+  Values are "on", "off" (defaults to "off").</xs:documentation>
+		</xs:annotation>
+		<xs:restriction>
+			<xs:simpleType>
+				<xs:union memberTypes="ipxact:simpleUnsignedBitExpression">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="on"/>
+							<xs:enumeration value="off"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:union>
+			</xs:simpleType>
+		</xs:restriction>
+	</xs:simpleType>
+-->
+	<xs:simpleType name="endianessType">
+		<xs:annotation>
+			<xs:documentation>'big': means the most significant element of any multi-element  data field is stored at the lowest memory address. 'little' means the least significant element of any multi-element data field is stored at the lowest memory address. If this element is not present the default is 'little' endian.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="big"/>
+			<xs:enumeration value="little"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="bitsInLau" type="ipxact:unsignedPositiveLongintExpression">
+		<xs:annotation>
+			<xs:documentation>The number of bits in the least addressable unit. The default is byte addressable (8 bits).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="viewRef">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:NMTOKEN">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="busInterface" type="ipxact:busInterfaceType">
+		<xs:annotation>
+			<xs:documentation>Describes one of the bus interfaces supported by this component.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="busInterfaces">
+		<xs:annotation>
+			<xs:documentation>A list of bus interfaces supported by this component.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:busInterface" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="busInterfaceType">
+		<xs:annotation>
+			<xs:documentation>Type definition for a busInterface in a component</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="busType" type="ipxact:configurableLibraryRefType">
+				<xs:annotation>
+					<xs:documentation>The bus type of this interface. Refers to bus definition using vendor, library, name, version attributes along with any configurable element values needed to configure this interface.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:abstractionTypes" minOccurs="0"/>
+			<xs:group ref="ipxact:interfaceMode">
+				<xs:annotation>
+					<xs:documentation>Indicates the usage mode of this instance of the bus interface.</xs:documentation>
+				</xs:annotation>
+			</xs:group>
+			<xs:element name="connectionRequired" type="xs:boolean" default="false" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indicates whether a connection to this interface is required for proper component functionality.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:bitsInLau" minOccurs="0"/>
+			<xs:element name="bitSteering" type="ipxact:unsignedBitExpression" default="0" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indicates whether bit steering should be used to map this interface onto a bus of different data width.
+
+Values are "0", "1" (defaults to "0").</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="endianness" type="ipxact:endianessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>'big': means the most significant element of any multi-element  data field is stored at the lowest memory address. 'little' means the least significant element of any multi-element data field is stored at the lowest memory address. If this element is not present the default is 'little' endian.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attributeGroup ref="ipxact:any.att"/>
+	</xs:complexType>
+	<xs:element name="group" type="xs:Name">
+		<xs:annotation>
+			<xs:documentation>Indicates which system interface is being mirrored. Name must match a group name present on one or more ports in the corresonding bus definition.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="channels">
+		<xs:annotation>
+			<xs:documentation>Lists all channel connections between mirror interfaces of this component.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="channel" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Defines a set of mirrored interfaces of this component that are connected to one another.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:element name="busInterfaceRef" minOccurs="2" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Contains the name of one of the bus interfaces that is part of this channel. The ordering of the references may be important to the design environment.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="localName" type="xs:Name"/>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="channelConnections">
+			<xs:selector xpath="ipxact:channel/ipxact:busInterfaceRef/ipxact:localName"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+		<xs:unique name="channelName">
+			<xs:selector xpath="ipxact:channel"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+	</xs:element>
+	<xs:group name="interfaceMode">
+		<xs:annotation>
+			<xs:documentation>Group of the different modes a busInterface can take on in a component</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="initiator">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface can serve as a initiator.  This element encapsulates additional information related to its role as initiator.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="addressSpaceRef" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>If this initiator connects to an addressable bus, this element references the address space it maps to.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:complexContent>
+									<xs:extension base="ipxact:addrSpaceRefType">
+										<xs:sequence>
+											<xs:annotation>
+												<xs:documentation>If the initiator's mapping to the physical address space is not zero based, the baseAddress element may be used to indicate the offset. If not specified the offset is 0. The baseAddress is in units of the addressSpace addressUnitBits</xs:documentation>
+											</xs:annotation>
+											<xs:element name="baseAddress" type="ipxact:signedLongintExpression" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation>Base of an address space.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="modeRef" minOccurs="0" maxOccurs="unbounded">
+												<xs:complexType>
+													<xs:annotation>
+														<xs:documentation>A reference to a mode.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleContent>
+														<xs:extension base="xs:Name">
+															<xs:attributeGroup ref="ipxact:id.att"/>
+														</xs:extension>
+													</xs:simpleContent>
+												</xs:complexType>
+											</xs:element>
+										</xs:sequence>
+									</xs:extension>
+								</xs:complexContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="target">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface can serve as a target.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:choice minOccurs="0">
+							<xs:element ref="ipxact:memoryMapRef"/>
+							<xs:element ref="ipxact:transparentBridge" maxOccurs="unbounded"/>
+						</xs:choice>
+						<xs:element name="fileSetRefGroup" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>This reference is used to point the filesets that are associated with this target port.
+
+Depending on the target port function, there may be completely different software drivers associated with the different ports. </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="group" type="xs:Name" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Abritray name assigned to the collections of fileSets.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element ref="ipxact:fileSetRef" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface is a system interface, neither initiator nor target, with a specific function on the bus.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:group"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="mirroredTarget">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface represents a mirrored target interface. All directional constraints on ports are reversed relative to the specification in the bus definition.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="baseAddresses" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Represents a set of remap base addresses.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="remapAddresses" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="remapAddress">
+													<xs:annotation>
+														<xs:documentation>Base of an address block, expressed as the number of bitsInLAU from the containing busInterface. The modeRef element indicates the name of the mode for which this address is valid.</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="ipxact:unsignedLongintExpression"/>
+														</xs:complexContent>
+													</xs:complexType>
+												</xs:element>
+												<xs:element ref="ipxact:modeRef" minOccurs="0" maxOccurs="unbounded"/>
+											</xs:sequence>
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="range" type="ipxact:unsignedPositiveLongintExpression">
+										<xs:annotation>
+											<xs:documentation>The address range of mirrored target, expressed as the number of bitsInLAU from the containing busInterface. </xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="mirroredInitiator">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface represents a mirrored initiator interface. All directional constraints on ports are reversed relative to the specification in the bus definition.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="mirroredSystem">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface represents a mirrored system interface. All directional constraints on ports are reversed relative to the specification in the bus definition.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:group"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="monitor">
+				<xs:annotation>
+					<xs:documentation>Indicates that this is a (passive) monitor interface. All of the ports in the interface must be inputs. The type of interface to be monitored is specified with the required interfaceType attribute. The ipxact:group element must be specified if monitoring a system interface.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:group" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Indicates which system interface is being monitored. Name must match a group name present on one or more ports in the corresonding bus definition.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="interfaceMode" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="initiator"/>
+								<xs:enumeration value="target"/>
+								<xs:enumeration value="system"/>
+								<xs:enumeration value="mirroredInitiator"/>
+								<xs:enumeration value="mirroredTarget"/>
+								<xs:enumeration value="mirroredSystem"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:element name="transparentBridge">
+		<xs:annotation>
+			<xs:documentation>If this element is present, it indicates that the bus interface provides a transparent bridge to another initiator bus interface on the same component.  It has a initiatorRef attribute which contains the name of the other bus interface.
+
+Any target interface can bridge to multiple initiator interfaces, and multiple target interfaces can bridge to the same initiator interface.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="initiatorRef" type="xs:Name" use="required">
+				<xs:annotation>
+					<xs:documentation>The name of the initiator bus interface to which this interface bridges.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:group name="abstractorInterfaceMode">
+		<xs:annotation>
+			<xs:documentation>Group of the different modes a busInterface can take on in an abstractor</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="initiator">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface can serve as a initiator.  This element encapsulates additional information related to its role as initiator.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="target">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface can serve as a target.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="system">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface is a system interface, neither initiator nor target, with a specific function on the bus.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:group"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="mirroredTarget">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface represents a mirrored target interface. All directional constraints on ports are reversed relative to the specification in the bus definition.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="mirroredInitiator">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface represents a mirrored initiator interface. All directional constraints on ports are reversed relative to the specification in the bus definition.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="mirroredSystem">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the bus interface represents a mirrored system interface. All directional constraints on ports are reversed relative to the specification in the bus definition.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:group"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:complexType name="abstractorBusInterfaceType">
+		<xs:annotation>
+			<xs:documentation>Type definition for a busInterface in a component</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element ref="ipxact:abstractionTypes" minOccurs="0"/>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attributeGroup ref="ipxact:any.att"/>
+	</xs:complexType>
+	<xs:element name="indirectInterface" type="ipxact:indirectInterfaceType">
+		<xs:annotation>
+			<xs:documentation>Describes one of the bus interfaces supported by this component.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="indirectInterfaces">
+		<xs:annotation>
+			<xs:documentation>A list of bus interfaces supported by this component.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:indirectInterface" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="indirectInterfaceType">
+		<xs:annotation>
+			<xs:documentation>Type definition for a indirectInterface in a component</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element ref="ipxact:indirectAddressRef"/>
+			<xs:element ref="ipxact:indirectDataRef"/>
+			<xs:choice>
+				<xs:element name="memoryMapRef" type="xs:Name">
+					<xs:annotation>
+						<xs:documentation>A reference to a memoryMap. This memoryMap is indirectly accessible through this interface.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:transparentBridge" maxOccurs="unbounded"/>
+			</xs:choice>
+			<xs:element ref="ipxact:bitsInLau" minOccurs="0"/>
+			<xs:element name="endianness" type="ipxact:endianessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>'big': means the most significant element of any multi-element  data field is stored at the lowest memory address. 'little' means the least significant element of any multi-element data field is stored at the lowest memory address. If this element is not present the default is 'little' endian.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:anyAttribute namespace="##any" processContents="lax"/>
+	</xs:complexType>
+	<xs:element name="indirectAddressRef">
+		<xs:annotation>
+			<xs:documentation>A reference to a field used for addressing the indirectly accessible memoryMap.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:group ref="ipxact:fieldReferenceGroup"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="indirectDataRef">
+		<xs:annotation>
+			<xs:documentation>A reference to a field used for read/write access to the indirectly accessible memoryMap.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:group ref="ipxact:fieldReferenceGroup"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="abstractionTypes">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="abstractionType" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>The abstraction type/level of this interface. Refers to abstraction definition using vendor, library, name, version attributes along with any configurable element values needed to configure this abstraction. Bus definition can be found through a reference in this file.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="ipxact:viewRef" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>A reference to a view name in the file for which this type applies.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="abstractionRef" type="ipxact:configurableLibraryRefType">
+								<xs:annotation>
+									<xs:documentation>Provides the VLNV of the abstraction type.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="portMaps" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Listing of maps between component ports and bus ports.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="portMap" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Maps a component's port to a port in a bus description. This is the logical to physical mapping. The logical pin comes from the bus interface and the physical pin from the component.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="logicalPort">
+														<xs:annotation>
+															<xs:documentation>Logical port from abstraction definition</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="name" type="xs:Name">
+																	<xs:annotation>
+																		<xs:documentation>Bus port name as specified inside the abstraction definition</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element ref="ipxact:range" minOccurs="0"/>
+															</xs:sequence>
+															<xs:attributeGroup ref="ipxact:id.att"/>
+														</xs:complexType>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="physicalPort">
+															<xs:annotation>
+																<xs:documentation>Physical port from this component</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="name" type="ipxact:portName">
+																		<xs:annotation>
+																			<xs:documentation>Component port name as specified inside the model port section</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+																	<xs:element name="subPort" minOccurs="0" maxOccurs="unbounded">
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="name" type="ipxact:portName">
+																					<xs:annotation>
+																						<xs:documentation>Component port subPort name as specified inside the model port section</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+																			</xs:sequence>
+																			<xs:attributeGroup ref="ipxact:id.att"/>
+																		</xs:complexType>
+																	</xs:element>
+																</xs:sequence>
+																<xs:attributeGroup ref="ipxact:id.att"/>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="logicalTieOff" type="ipxact:unsignedBitVectorExpression">
+															<xs:annotation>
+																<xs:documentation>Identifies a value to tie this logical port to.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+													<xs:element name="isInformative" type="xs:boolean" default="false" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>When true, indicates that this portMap element is for information purpose only.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+												</xs:sequence>
+												<xs:attributeGroup ref="ipxact:id.att"/>
+												<xs:attribute name="invert" use="optional" default="false">
+													<xs:annotation>
+														<xs:documentation>Indicates that the connection between the logical and physical ports should include an inversion.</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="abstractionTypeViewRefUnique">
+			<xs:selector xpath="ipxact:abstractionType/ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/catalog.xsd
+++ b/ieee-1685-2022/catalog.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:Q1="ipxact" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="fileType.xsd"/>
+	<xs:annotation>
+		<xs:documentation>This is the IP-XACT catalog definition</xs:documentation>
+	</xs:annotation>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:complexType name="ipxactFilesType">
+		<xs:annotation>
+			<xs:documentation>Contains a list of IP-XACT files to include.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ipxactFile" type="ipxact:ipxactFileType" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="catalog">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:element name="catalogs" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="busDefinitions" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="abstractionDefinitions" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="components" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="abstractors" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="designs" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="designConfigurations" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="generatorChains" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element name="typeDefinitions" type="ipxact:ipxactFilesType" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:unique name="catalogFileNameUnique">
+			<xs:selector xpath=".//ipxact:ipxactFile"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+		<xs:unique name="catalogVLNVUnique">
+			<xs:selector xpath=".//ipxact:ipxactFile/ipxact:vlnv"/>
+			<xs:field xpath="@vendor"/>
+			<xs:field xpath="@library"/>
+			<xs:field xpath="@name"/>
+			<xs:field xpath="@version"/>
+		</xs:unique>
+	</xs:element>
+	<xs:complexType name="ipxactFileType">
+		<xs:sequence>
+			<xs:element name="vlnv" type="ipxact:libraryRefType">
+				<xs:annotation>
+					<xs:documentation>VLNV of the IP-XACT file being cataloged.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="name" type="ipxact:ipxactURI">
+				<xs:annotation>
+					<xs:documentation>Name of the IP-XACT file being cataloged.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/commonStructures.xsd
+++ b/ieee-1685-2022/commonStructures.xsd
@@ -1,0 +1,1134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="autoConfigure.xsd"/>
+	<xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:element name="parameter" type="ipxact:parameterType">
+		<xs:annotation>
+			<xs:documentation>A name value pair.  The name is specified by the name element.  The value is in the text content of the value element.  This value element supports all configurability attributes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="assertion">
+		<xs:annotation>
+			<xs:documentation>Provides an expression for describing valid parameter value settings.  If a assertion assert expression evaluates false, the name, displayName and/or description can be used to communicate the assertion failure.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroup"/>
+				<xs:element name="assert" type="ipxact:unsignedBitExpression"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="assertions">
+		<xs:annotation>
+			<xs:documentation>List of assertions about allowed parameter values.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:assertion" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="qualifierType">
+		<xs:sequence>
+			<xs:element name="isAddress" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port contains address information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isData" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port contains data information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isClock" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port contains only clock information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isReset" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port contains only reset information.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:boolean">
+							<xs:attribute name="level">
+								<xs:annotation>
+									<xs:documentation>Assertion level</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:enumeration value="low"/>
+										<xs:enumeration value="high"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="isValid" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port signifies that the data on the interface is currently valid</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isInterrupt" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port contains only interrupt information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isClockEn" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port indicates that an associated conditional clock should be turned on.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:boolean">
+							<xs:attribute name="level">
+								<xs:annotation>
+									<xs:documentation>Assertion level</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:enumeration value="low"/>
+										<xs:enumeration value="high"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="isPowerEn" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port indicates that an associated power domain should be activated.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:boolean">
+							<xs:attribute name="level">
+								<xs:annotation>
+									<xs:documentation>Assertion level</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:enumeration value="low"/>
+										<xs:enumeration value="high"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+							<xs:attribute name="powerDomainRef" type="xs:string">
+								<xs:annotation>
+									<xs:documentation>PowerDomain references</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="isOpcode" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port determines the interpretation of other signals in the interface.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isProtection" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port implements a protection signal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isFlowControl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port is used by the interface’s flow control mechanism.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:boolean">
+							<xs:attribute name="flowType">
+								<xs:annotation>
+									<xs:documentation>Controlled flow type</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:enumeration value="credit-return"/>
+										<xs:enumeration value="ready"/>
+										<xs:enumeration value="busy"/>
+										<xs:enumeration value="user"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:attribute>
+							<xs:attribute name="user" type="xs:string">
+								<xs:annotation>
+									<xs:documentation>User flow type information</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="isUser" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port is used for user defined behavior.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:boolean">
+							<xs:attribute name="user" type="xs:string">
+								<xs:annotation>
+									<xs:documentation>User behaviour</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="isRequest" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port implements a request signal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="isResponse" type="xs:boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If this element is present, the port implements a response signal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="parameters">
+		<xs:annotation>
+			<xs:documentation>A collection of parameters and associated value assertions.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:parameter" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+		<!--		
+		<xs:unique name="parameterNameUnique">
+			<xs:selector xpath="./ipxact:parameter"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+-->
+	</xs:element>
+	<xs:element name="vendorExtensions">
+		<xs:annotation>
+			<xs:documentation>Container for vendor specific extensions.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:any namespace="##any" processContents="lax" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Accepts any element(s) the content provider wants to put here, including elements from the ipxact namespace.</xs:documentation>
+					</xs:annotation>
+				</xs:any>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:group name="nameGroup">
+		<xs:annotation>
+			<xs:documentation>A group of elements for name (xs:name), displayName and description</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="name" type="xs:Name">
+				<xs:annotation>
+					<xs:documentation>Unique name</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:displayName" minOccurs="0"/>
+			<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="portAccessHandle">
+		<xs:sequence>
+			<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>A list of views this accessHandle is applicable to. Note this element is optional, if it is not present the accessHandle applies to all views.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:Name">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="indices" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>For a multi dimensional IP-XACT object, indices can be specified to select the element the accessHandle applies to. This is an index into a multi-dimensional array and follows C-semantics for indexing.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="index" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>An index into the IP-XACT object.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="ipxact:unsignedIntExpression">
+										<xs:attributeGroup ref="ipxact:id.att"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="slices" type="ipxact:portSlicesType"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="force" type="xs:boolean" default="true"/>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="slicedAccessHandle">
+		<xs:sequence>
+			<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>A list of views this accessHandle is applicable to. Note this element is optional, if it is not present the accessHandle applies to all views.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:Name">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="slices" type="ipxact:slicesType"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="force" type="xs:boolean" default="true"/>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="simpleAccessHandle">
+		<xs:sequence>
+			<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>A list of views this accessHandle is applicable to. Note this element is optional, if it is not present the accessHandle applies to all views.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:Name">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="pathSegments">
+				<xs:annotation>
+					<xs:documentation>An ordered list of pathSegment elements. When concatenated with a desired separator the elements in this form a HDL path for the parent slice into the referenced view.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pathSegment" type="ipxact:pathSegmentType" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="slicesType">
+		<xs:annotation>
+			<xs:documentation>Each slice specifies the HDL path for part of the parent IP-XACT object. The slices must be concatenated to calculate the entire path. If there is only one slice, it is assumed to be the path for the entire IP-XACT object.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="slice" type="ipxact:sliceType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The HDL path for a slice of the IP-XACT object.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="sliceType">
+		<xs:annotation>
+			<xs:documentation>Contains the HDL path information for a slice of the IP-XACT object. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pathSegments">
+				<xs:annotation>
+					<xs:documentation>An ordered list of pathSegment elements. When concatenated with a desired separator the elements in this form a HDL path for the parent slice into the referenced view.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pathSegment" type="ipxact:pathSegmentType" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:range" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A range to be applied to the concatenation of the above path segments</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="pathSegmentType">
+		<xs:annotation>
+			<xs:documentation>Identifies one level of hierarchy in the view specifed by viewNameRef. This is a simple name and optionally some indices into a multi dimensional element.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:unresolvedStringExpression">
+				<xs:attributeGroup ref="ipxact:id.att"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="portSlicesType">
+		<xs:annotation>
+			<xs:documentation>Each slice specifies the HDL path for part of the parent IP-XACT object. The slices must be concatenated to calculate the entire path. If there is only one slice, it is assumed to be the path for the entire IP-XACT object.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="slice" type="ipxact:portSliceType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The HDL path for a slice of the IP-XACT object.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="portSliceType">
+		<xs:annotation>
+			<xs:documentation>Contains the HDL path information for a slice of the IP-XACT object. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pathSegments">
+				<xs:annotation>
+					<xs:documentation>An ordered list of pathSegment elements. When concatenated with a desired separator the elements in this form a HDL path for the parent slice into the referenced view.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pathSegment" type="ipxact:portPathSegmentType" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:range" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A range to be applied to the concatenation of the above path segments</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="portPathSegmentType">
+		<xs:annotation>
+			<xs:documentation>Identifies one level of hierarchy in the view specifed by viewNameRef. This is a simple name and optionally some indices into a multi dimensional element.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:stringExpression">
+				<xs:attributeGroup ref="ipxact:id.att"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:element name="right" type="ipxact:unsignedIntExpression">
+		<xs:annotation>
+			<xs:documentation>The optional element right specifies the right boundary.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="left" type="ipxact:unsignedIntExpression">
+		<xs:annotation>
+			<xs:documentation>The optional element left specifies the left boundary.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:group name="nameGroupOptional">
+		<xs:annotation>
+			<xs:documentation>A group of elements for name (xs:name), displayName and description where the name is optional</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="name" type="xs:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Unique name</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:displayName" minOccurs="0"/>
+			<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="nameGroupNMTOKEN">
+		<xs:annotation>
+			<xs:documentation>A group of elements for name(xs:NMTOKEN), displayName and description</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="name" type="xs:NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Unique name</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:displayName" minOccurs="0"/>
+			<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="nameGroupPort">
+		<xs:annotation>
+			<xs:documentation>A group of elements for name(portName), displayName and description</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="name" type="ipxact:portName">
+				<xs:annotation>
+					<xs:documentation>Unique name</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:displayName" minOccurs="0"/>
+			<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="parameterType">
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupString"/>
+			<xs:element ref="ipxact:vectors" minOccurs="0"/>
+			<xs:element name="arrays" type="ipxact:configurableArrays" minOccurs="0"/>
+			<xs:element ref="ipxact:value"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attributeGroup ref="ipxact:parameter.att"/>
+		<xs:attributeGroup ref="ipxact:parameter.resolve.att"/>
+		<xs:attributeGroup ref="ipxact:any.att"/>
+	</xs:complexType>
+	<xs:complexType name="moduleParameterType">
+		<xs:annotation>
+			<xs:documentation>Name value pair with data type information.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupString"/>
+			<xs:element name="vectors" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vector" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Left and right ranges of the vector.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element ref="ipxact:left"/>
+									<xs:element ref="ipxact:right"/>
+								</xs:sequence>
+								<xs:attribute name="vectorId" type="xs:Name"/>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+				<xs:unique name="ModuleParameterVectorIdUnique">
+					<xs:selector xpath="ipxact:vector"/>
+					<xs:field xpath="@vectorId"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="arrays" type="ipxact:moduleParameterArrays" minOccurs="0">
+				<xs:unique name="ModuleParameterArrayIdUnique">
+					<xs:selector xpath="ipxact:array"/>
+					<xs:field xpath="@arrayId"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element ref="ipxact:value"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attributeGroup ref="ipxact:parameter.att"/>
+		<xs:attributeGroup ref="ipxact:parameter.resolve.att"/>
+		<xs:attributeGroup ref="ipxact:any.att"/>
+		<xs:attribute name="dataType" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>The data type of the argument as pertains to the language. Example: "int", "double", "char *".</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="usageType" default="typed">
+			<xs:annotation>
+				<xs:documentation>Indicates the type of the module parameter. Legal values are defined in the attribute enumeration list. Default value is 'typed'.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="nontyped"/>
+					<xs:enumeration value="typed"/>
+					<xs:enumeration value="runtime"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="dataTypeDefinition" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>The dataTypeDefinition references a file, which is included in the filesetRef referenced from the componentInstantiation.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="constrained">
+			<xs:annotation>
+				<xs:documentation>Indicates for which vectors and arrays the number of bits in the type declaration is fixed by referencing the vectorId and arrayId values. The values are separated by whitespace.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:list itemType="xs:Name"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="nameValuePairType">
+		<xs:annotation>
+			<xs:documentation>Name and value type for use in resolvable elements</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupString"/>
+			<xs:element ref="ipxact:value"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="vector">
+		<xs:annotation>
+			<xs:documentation>Left and right ranges of the vector.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:left"/>
+				<xs:element ref="ipxact:right"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+			<!-- <xs:attribute name="vectorId" type="xs:Name"/> -->
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="vectors">
+		<xs:annotation>
+			<xs:documentation>Vectored information.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:vector" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="range">
+		<xs:annotation>
+			<xs:documentation>Left and right bound of a reference into a vector.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:left"/>
+				<xs:element ref="ipxact:right"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="partSelect">
+		<xs:annotation>
+			<xs:documentation>Bit range definition.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:choice>
+				<xs:element ref="ipxact:range"/>
+				<xs:sequence>
+					<xs:element ref="ipxact:indices"/>
+					<xs:element ref="ipxact:range" minOccurs="0"/>
+				</xs:sequence>
+			</xs:choice>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="subPortReference">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="subPortRef" type="ipxact:portName" use="required">
+				<xs:annotation>
+					<xs:documentation>A subPort on the referenced structured port.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="addressBlockRef">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:indices" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="addressBlockRef" type="xs:Name" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="registerFileRef">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:indices" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="registerFileRef" type="xs:Name" use="required"/>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="registerRef">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:indices" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="registerRef" type="xs:Name" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="alternateRegisterRef">
+		<xs:complexType>
+			<xs:attribute name="alternateRegisterRef" type="xs:Name" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fieldRef">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:indices" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="fieldRef" type="xs:Name" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="bankRef">
+		<xs:complexType>
+			<xs:attribute name="bankRef" type="xs:Name" use="required"/>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="memoryRemapRef">
+		<xs:complexType>
+			<xs:attribute name="memoryRemapRef" type="xs:Name" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:group name="fieldSliceReferenceGroup">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="addressSpaceRef">
+					<xs:complexType>
+						<xs:attribute name="addressSpaceRef" type="xs:Name" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:sequence>
+					<xs:element name="memoryMapRef">
+						<xs:complexType>
+							<xs:attribute name="memoryMapRef" type="xs:Name" use="required"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element ref="ipxact:memoryRemapRef" minOccurs="0"/>
+				</xs:sequence>
+			</xs:choice>
+			<xs:element ref="ipxact:bankRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:addressBlockRef"/>
+			<xs:element ref="ipxact:registerFileRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:registerRef"/>
+			<xs:element ref="ipxact:alternateRegisterRef" minOccurs="0"/>
+			<xs:element ref="ipxact:fieldRef"/>
+			<xs:element ref="ipxact:range" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="fieldReferenceGroup">
+		<xs:sequence>
+			<xs:choice minOccurs="0">
+				<xs:element name="addressSpaceRef">
+					<xs:complexType>
+						<xs:attribute name="addressSpaceRef" type="xs:Name" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:sequence>
+					<xs:element name="memoryMapRef">
+						<xs:complexType>
+							<xs:attribute name="memoryMapRef" type="xs:Name" use="required"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element ref="ipxact:memoryRemapRef" minOccurs="0"/>
+				</xs:sequence>
+			</xs:choice>
+			<xs:element ref="ipxact:bankRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:addressBlockRef" minOccurs="0"/>
+			<xs:element ref="ipxact:registerFileRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:registerRef" minOccurs="0"/>
+			<xs:element ref="ipxact:alternateRegisterRef" minOccurs="0"/>
+			<xs:element ref="ipxact:fieldRef"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="configurableArrays">
+		<xs:sequence>
+			<xs:element name="array" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Specific left and right array bounds.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:left"/>
+						<xs:element ref="ipxact:right"/>
+					</xs:sequence>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="moduleParameterArrays">
+		<xs:sequence>
+			<xs:element name="array" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Specific left and right array bounds.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:left"/>
+						<xs:element ref="ipxact:right"/>
+					</xs:sequence>
+					<xs:attribute name="arrayId" type="xs:Name"/>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="value" type="ipxact:stringExpression">
+		<xs:annotation>
+			<xs:documentation>The value of the parameter.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:group name="nameGroupString">
+		<xs:annotation>
+			<xs:documentation>A group of elements for name(xs:string), displayName and description</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="name" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Unique name</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:displayName" minOccurs="0"/>
+			<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:element name="displayName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Element name for display purposes. Typically a few words providing a more detailed and/or user-friendly name than the ipxact:name.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="shortDescription" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Brief description suitable for titles, software comments and pop-up windows. Being a SystemVerilog expression the text can be constructed using parameters, e.g, by concatentation or $sformatf().</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="description" type="xs:string">
+		<xs:annotation>
+			<xs:documentation>Full description string, typically for documentation</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="indicesType">
+		<xs:sequence>
+			<xs:element ref="ipxact:index" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="modeLinks">
+		<xs:annotation>
+			<xs:documentation>A set of links between internal and external modes defined in the typeDefinitions document.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="modeLink" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A link between one external mode and one internal mode.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="externalModeReference">
+								<xs:annotation>
+									<xs:documentation>Reference to a mode defined in the linked external type definitions.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="modeRef" type="xs:Name" use="required">
+										<xs:annotation>
+											<xs:documentation>Reference to a specific mode.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="modeReference">
+								<xs:annotation>
+									<xs:documentation>Reference to a mode defined internally.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="modeRef" type="xs:Name" use="required">
+										<xs:annotation>
+											<xs:documentation>Reference to a specific mode.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="modeLinksModeReferenceUnique">
+			<xs:selector xpath="ipxact:modeLink/ipxact:modeReference"/>
+			<xs:field xpath="@modeRef"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="viewLinks">
+		<xs:annotation>
+			<xs:documentation>A set of links between internal and external views defined in the typeDefinitions document.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="viewLink" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A link between one external view and one internal view.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="externalViewReference">
+								<xs:annotation>
+									<xs:documentation>Reference to a view defined in the linked external type definitions.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="viewRef" type="xs:Name" use="required">
+										<xs:annotation>
+											<xs:documentation>Reference to a specific view.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="viewReference">
+								<xs:annotation>
+									<xs:documentation>Reference to a view defined internally.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="viewRef" type="xs:Name" use="required">
+										<xs:annotation>
+											<xs:documentation>Reference to a specific view.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="viewLinksViewReferenceUnique">
+			<xs:selector xpath="ipxact:viewLink/ipxact:viewReference"/>
+			<xs:field xpath="@viewRef"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="resetTypeLinks">
+		<xs:annotation>
+			<xs:documentation>A set of links between internal and external resetTypes defined in the typeDefinitions document.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="resetTypeLink" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A link between one external reset type and one internal resetType.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="externalResetTypeReference">
+								<xs:annotation>
+									<xs:documentation>Reference to a resetType defined in the linked external type definitions.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="resetTypeRef" type="xs:Name" use="required">
+										<xs:annotation>
+											<xs:documentation>Reference to a specific resetType.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="resetTypeReference">
+								<xs:annotation>
+									<xs:documentation>Reference to a resetType defined internally.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="resetTypeRef" type="xs:Name" use="required">
+										<xs:annotation>
+											<xs:documentation>Reference to a specific resetType</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="resetTypeLinksViewReferenceUnique">
+			<xs:selector xpath="ipxact:resetTypeLink/ipxact:resetTypeReference"/>
+			<xs:field xpath="@resetTypeRef"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="index">
+		<xs:annotation>
+			<xs:documentation>An index into an object in the referenced view.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:unsignedIntExpression">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="indices" type="ipxact:indicesType"/>
+	<xs:attributeGroup name="parameter.att">
+		<xs:attribute name="parameterId" type="xs:Name">
+			<xs:annotation>
+				<xs:documentation>ID attribute for uniquely identifying a parameter within its document. Attribute is used to refer to this from a configurable element.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="prompt" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>Provides a string used to prompt the user for user-resolved property values.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="choiceRef" type="xs:Name">
+			<xs:annotation>
+				<xs:documentation>For user defined properties, refers the choice element enumerating the values to choose from.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="order" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>For components with auto-generated configuration forms, the user-resolved properties with order attibutes will be presented in ascending order.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="configGroups" type="xs:NMTOKENS">
+			<xs:annotation>
+				<xs:documentation>Tags configurable properties so that they may be grouped together.  Configurable properties with matching values for this attribute are contained in the same group. The format of this attribute is a string. There is no semantic meaning to this attribute.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="minimum" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>For user-resolved properties with numeric values, this indicates the minimum value allowed. Only valid for the types: byte, shortint, int, longint, shortreal and real. The type of this value is the same as the type of the parameter-value, which is specified by the parameter-type attribute.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="maximum" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>For user-resolved properties with numeric values, this indicates the maximum value allowed. Only valid for the types: byte, shortint, int, longint, shortreal and real. The type of this value is the same as the type of the parameter-value, which is specified by the parameter-type attribute.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="type" type="ipxact:formatType" default="string">
+			<xs:annotation>
+				<xs:documentation>Specifies the type of the value of the parameter. A parameter of type byte is resolved to an 8-bit integer value, shortint is resolved to a 16-bit integer value, int is resolved to a 32-bit integer value, longint is resolved to a 64-bit integer value, shortreal is resolved to a 32-bit floating point value, real is resolved to a 64-bit floating point value, bit is by default resolved to a one bit value, unless a vector size has been specified and the string type is resolved to a string value.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="sign" type="ipxact:signType">
+			<xs:annotation>
+				<xs:documentation>Specify the signedness explicitly. The data types byte, shortint, int, longint default to signed. The data type bit defaults to unsigned. When setting this values for the data types string, real and shortreal the setting is ignored.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="prefix">
+			<xs:annotation>
+				<xs:documentation>Defines the prefix that precedes the unit of a value. The prefix is not applied to the value (e.g. in calculations).</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="deca"/>
+					<xs:enumeration value="hecto"/>
+					<xs:enumeration value="kilo"/>
+					<xs:enumeration value="mega"/>
+					<xs:enumeration value="giga"/>
+					<xs:enumeration value="tera"/>
+					<xs:enumeration value="peta"/>
+					<xs:enumeration value="exa"/>
+					<xs:enumeration value="zetta"/>
+					<xs:enumeration value="yotta"/>
+					<xs:enumeration value="deci"/>
+					<xs:enumeration value="centi"/>
+					<xs:enumeration value="milli"/>
+					<xs:enumeration value="micro"/>
+					<xs:enumeration value="nano"/>
+					<xs:enumeration value="pico"/>
+					<xs:enumeration value="femto"/>
+					<xs:enumeration value="atto"/>
+					<xs:enumeration value="zepto"/>
+					<xs:enumeration value="yocto"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="unit">
+			<xs:annotation>
+				<xs:documentation>Defines the unit of the value.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="second"/>
+					<xs:enumeration value="ampere"/>
+					<xs:enumeration value="kelvin"/>
+					<xs:enumeration value="hertz"/>
+					<xs:enumeration value="joule"/>
+					<xs:enumeration value="watt"/>
+					<xs:enumeration value="coulomb"/>
+					<xs:enumeration value="volt"/>
+					<xs:enumeration value="farad"/>
+					<xs:enumeration value="ohm"/>
+					<xs:enumeration value="siemens"/>
+					<xs:enumeration value="henry"/>
+					<xs:enumeration value="Celsius"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="parameter.unit.att">
+		<xs:attribute name="unit">
+			<xs:annotation>
+				<xs:documentation>Defines the unit of the value.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="second"/>
+					<xs:enumeration value="ampere"/>
+					<xs:enumeration value="kelvin"/>
+					<xs:enumeration value="hertz"/>
+					<xs:enumeration value="joule"/>
+					<xs:enumeration value="watt"/>
+					<xs:enumeration value="coulomb"/>
+					<xs:enumeration value="volt"/>
+					<xs:enumeration value="farad"/>
+					<xs:enumeration value="ohm"/>
+					<xs:enumeration value="siemens"/>
+					<xs:enumeration value="henry"/>
+					<xs:enumeration value="Celsius"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="parameter.resolve.att">
+		<xs:attribute name="resolve" default="immediate">
+			<xs:annotation>
+				<xs:documentation>Determines how a property value can be configured.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:annotation>
+					<xs:documentation>Determines how a parameter is resolved. User means the value must be obtained from the user. Generated means the value will be provided by a generator.</xs:documentation>
+				</xs:annotation>
+				<xs:restriction base="xs:token">
+					<xs:enumeration value="immediate">
+						<xs:annotation>
+							<xs:documentation>Property content cannot be modified through configuration.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="user">
+						<xs:annotation>
+							<xs:documentation>Property content can be modified through configuration. Modifications will be saved with the design.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="generated">
+						<xs:annotation>
+							<xs:documentation>Generators may modify this property. Modifications get saved with the design.</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:attributeGroup>
+</xs:schema>

--- a/ieee-1685-2022/component.xsd
+++ b/ieee-1685-2022/component.xsd
@@ -1,0 +1,441 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="busInterface.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="generator.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="model.xsd"/>
+	<xs:include schemaLocation="subInstances.xsd"/>
+	<xs:include schemaLocation="constraints.xsd"/>
+	<xs:complexType name="componentType">
+		<xs:annotation>
+			<xs:documentation>Component-specific extension to componentType</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:documentNameGroup"/>
+			<xs:element name="typeDefinitions" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element ref="ipxact:externalTypeDefinitions" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="powerDomains" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="powerDomain" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="ipxact:nameGroup"/>
+									<xs:element ref="ipxact:alwaysOn" minOccurs="0"/>
+									<xs:element name="subDomainOf" type="xs:Name" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Reference to a power domain defined on this component</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element ref="ipxact:parameters" minOccurs="0"/>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:busInterfaces" minOccurs="0"/>
+			<xs:element ref="ipxact:indirectInterfaces" minOccurs="0"/>
+			<xs:element ref="ipxact:channels" minOccurs="0"/>
+			<xs:element name="modes" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A list of user defined component modes.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="mode" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="ipxact:nameGroup"/>
+									<xs:element name="portSlice" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="ipxact:nameGroup"/>
+												<xs:element name="portRef">
+													<xs:complexType>
+														<xs:attribute name="portRef" use="required"/>
+													</xs:complexType>
+												</xs:element>
+												<xs:element ref="ipxact:subPortReference" minOccurs="0" maxOccurs="unbounded"/>
+												<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+											</xs:sequence>
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="fieldSlice" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Reference to a register field slice</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:group ref="ipxact:nameGroup"/>
+												<xs:group ref="ipxact:fieldSliceReferenceGroup"/>
+											</xs:sequence>
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="condition" type="ipxact:unresolvedUnsignedBitExpression" minOccurs="0"/>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:addressSpaces" minOccurs="0"/>
+			<xs:element ref="ipxact:memoryMaps" minOccurs="0"/>
+			<xs:element ref="ipxact:model" minOccurs="0"/>
+			<xs:element ref="ipxact:componentGenerators" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Generator list is tools-specific.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:choices" minOccurs="0"/>
+			<xs:element ref="ipxact:fileSets" minOccurs="0"/>
+			<xs:element name="clearboxElements" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A list of clearboxElements</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="clearboxElement" type="ipxact:clearboxElementType" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>A clearboxElement is a useful way to identify elements of a component that can not be identified through other means such as internal signals and non-software accessible registers.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="cpus" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>cpu's in the component</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cpu" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Describes a processor in this component.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="ipxact:nameGroup">
+										<xs:annotation>
+											<xs:documentation>The name of the cpu instance relative to the platform core.</xs:documentation>
+										</xs:annotation>
+									</xs:group>
+									<xs:group ref="ipxact:blockSize"/>
+									<xs:element name="regions" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Address regions within a cpu system address map.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="region" maxOccurs="unbounded">
+													<xs:annotation>
+														<xs:documentation>Address region within a system address map.</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:group ref="ipxact:nameGroup"/>
+															<xs:element name="addressOffset" type="ipxact:unsignedLongintExpression">
+																<xs:annotation>
+																	<xs:documentation>Address offset of the region within the system address map.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="range" type="ipxact:unsignedPositiveLongintExpression">
+																<xs:annotation>
+																	<xs:documentation>The address range of region. Expressed as the number of addressable units accessible to the region.			</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+														</xs:sequence>
+														<xs:attributeGroup ref="ipxact:id.att"/>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+									<xs:element ref="ipxact:executableImage" minOccurs="0" maxOccurs="unbounded"/>
+									<xs:element name="memoryMapRef" type="xs:Name">
+										<xs:annotation>
+											<xs:documentation>Indicates which memory maps into this cpu.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element ref="ipxact:parameters" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data specific to the cpu.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+							<xs:unique name="regionNameUnique">
+								<xs:selector xpath="ipxact:regions/ipxact:region"/>
+								<xs:field xpath="ipxact:name"/>
+							</xs:unique>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+				<xs:unique name="cpuNameUnique">
+					<xs:selector xpath="ipxact:cpu"/>
+					<xs:field xpath="ipxact:name"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="otherClockDrivers" type="ipxact:otherClocks" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Defines a set of clock drivers that are not directly associated with an input port of the component.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="resetTypes" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A list of user defined resetTypes applicable to this component.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="resetType" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>A user defined reset policy</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="ipxact:nameGroup"/>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:assertions" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="component" type="ipxact:componentType">
+		<xs:annotation>
+			<xs:documentation>This is the root element for all non platform-core components.</xs:documentation>
+		</xs:annotation>
+		<xs:key name="indirectInterfaceKey">
+			<xs:selector xpath="ipxact:indirectInterfaces/ipxact:indirectInterface"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="interfaceKey">
+			<xs:selector xpath="ipxact:busInterfaces/ipxact:busInterface"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="interfaceRef" refer="ipxact:interfaceKey">
+			<xs:selector xpath="ipxact:busInterfaces/ipxact:busInterface/ipxact:target/ipxact:transparentBridge"/>
+			<xs:field xpath="@initiatorRef"/>
+		</xs:keyref>
+		<xs:keyref name="channelInterfaceRef" refer="ipxact:interfaceKey">
+			<xs:selector xpath="ipxact:channels/ipxact:channel/ipxact:busInterfaceRef/ipxact:localName"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="subspaceMapRef" refer="ipxact:interfaceKey">
+			<xs:selector xpath=".//ipxact:subspaceMap"/>
+			<xs:field xpath="@initiatorRef"/>
+		</xs:keyref>
+		<xs:key name="addressSpaceKey">
+			<xs:selector xpath="ipxact:addressSpaces/ipxact:addressSpace"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="addressSpaceRef" refer="ipxact:addressSpaceKey">
+			<xs:selector xpath=".//ipxact:addressSpaceRef"/>
+			<xs:field xpath="@addressSpaceRef"/>
+		</xs:keyref>
+		<xs:key name="memoryMapKey">
+			<xs:selector xpath="ipxact:memoryMaps/ipxact:memoryMap"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="memoryMapRef" refer="ipxact:memoryMapKey">
+			<xs:selector xpath=".//ipxact:memoryMapRef"/>
+			<xs:field xpath="@memoryMapRef"/>
+		</xs:keyref>
+		<xs:keyref name="indirectMemoryMapRef" refer="ipxact:memoryMapKey">
+			<xs:selector xpath="ipxact:indirectInterfaces/ipxact:indirectInterface/ipxact:memoryMapRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="cpuMemoryMapRef" refer="ipxact:memoryMapKey">
+			<xs:selector xpath="ipxact:cpus/ipxact:cpu/ipxact:memoryMapRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:unique name="parameterConstraint">
+			<xs:selector xpath=".//ipxact:parameter | .//ipxact:moduleParameter | .//ipxact:typeParameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:unique name="resetTypeKey">
+			<xs:selector xpath="ipxact:resetTypes/ipxact:resetType"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+		<xs:keyref name="resetTypeRef" refer="ipxact:resetTypeKey">
+			<xs:selector xpath=".//ipxact:field/ipxact:resets/ipxact:reset | .//ipxact:ports/ipxact:port/ipxact:isReset"/>
+			<xs:field xpath="@resetTypeRef"/>
+		</xs:keyref>
+		<xs:key name="componentChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:keyref name="componentChoiceRef" refer="ipxact:componentChoiceKey">
+			<xs:selector xpath=".//ipxact:parameter | .//ipxact:moduleParameter | .//ipxact:typeParameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+		<xs:key name="componentViewKey">
+			<xs:selector xpath="ipxact:model/ipxact:views/ipxact:view"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="componentTypeDefViewRef" refer="ipxact:componentViewKey">
+			<xs:selector xpath=".//ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="componentViewLinkViewRef" refer="ipxact:componentViewKey">
+			<xs:selector xpath=".//ipxact:viewLink/ipxact:viewReference"/>
+			<xs:field xpath="@viewRef"/>
+		</xs:keyref>
+		<xs:key name="fileSetKey">
+			<xs:selector xpath=".//ipxact:fileSet"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="fileSetRef" refer="ipxact:fileSetKey">
+			<xs:selector xpath=".//ipxact:fileSetRef"/>
+			<xs:field xpath="ipxact:localName"/>
+		</xs:keyref>
+		<xs:key name="executableImageKey">
+			<xs:selector xpath=".//ipxact:executableImage"/>
+			<xs:field xpath="@imageId"/>
+		</xs:key>
+		<xs:unique name="executableImageName">
+			<xs:selector xpath=".//ipxact:executableImage"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+		<xs:unique name="fileKey">
+			<xs:selector xpath=".//ipxact:file"/>
+			<xs:field xpath="@fileId"/>
+		</xs:unique>
+		<xs:keyref name="fileRef" refer="ipxact:fileKey">
+			<xs:selector xpath=".//ipxact:function"/>
+			<xs:field xpath="ipxact:fileRef"/>
+		</xs:keyref>
+		<xs:key name="modeKey">
+			<xs:selector xpath="ipxact:modes/ipxact:mode"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="memoryRemapModeRef" refer="ipxact:modeKey">
+			<xs:selector xpath="ipxact:memoryMaps/ipxact:memoryMap/ipxact:memoryRemap/ipxact:modeRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="componentModeLinkModeRef" refer="ipxact:modeKey">
+			<xs:selector xpath=".//ipxact:modeLink/ipxact:modeReference"/>
+			<xs:field xpath="@modeRef"/>
+		</xs:keyref>
+		<xs:keyref name="componentModeRef" refer="ipxact:modeKey">
+			<xs:selector xpath=".//ipxact:modeRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:key name="portKey">
+			<xs:selector xpath="ipxact:model/ipxact:ports/ipxact:port"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="portMapPortRef" refer="ipxact:portKey">
+			<xs:selector xpath="ipxact:busInterfaces/ipxact:busInterface/ipxact:abstractionTypes/ipxact:abstractionType/ipxact:portMaps/ipxact:portMap/ipxact:physicalPort/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="portSlicePortRef" refer="ipxact:portKey">
+			<xs:selector xpath="ipxact:modes/ipxact:mode/ipxact:portSlice/ipxact:portRef"/>
+			<xs:field xpath="@portRef"/>
+		</xs:keyref>
+		<!--		<xs:keyref name="remapStatePortRef" refer="ipxact:portKey">
+			<xs:selector xpath="ipxact:remapStates/ipxact:remapState/ipxact:remapPorts/ipxact:remapPort"/>
+			<xs:field xpath="@portRef"/>
+		</xs:keyref>
+-->
+		<xs:key name="clearboxKey">
+			<xs:selector xpath="ipxact:clearboxElements/ipxact:clearboxElement"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="clearboxRef" refer="ipxact:clearboxKey">
+			<xs:selector xpath="ipxact:model/ipxact:instantiations/ipxact:componentInstantiation/ipxact:clearboxElementRefs/ipxact:clearboxElementRef"/>
+			<xs:field xpath="@name"/>
+		</xs:keyref>
+		<xs:key name="componentGeneratorKey">
+			<xs:selector xpath="ipxact:componentGenerators/ipxact:componentGenerator"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="componentGeneratorRef" refer="ipxact:componentGeneratorKey">
+			<xs:selector xpath=".//ipxact:generatorRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:key name="powerDomainKey">
+			<xs:selector xpath="ipxact:powerDomains/ipxact:powerDomain"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="powerDomainRef" refer="ipxact:powerDomainKey">
+			<xs:selector xpath=".//ipxact:powerDomainRef | .//ipxact:subDomainOf"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:key name="externalTypeDefinitionsKey">
+			<xs:selector xpath="ipxact:typeDefinitions/ipxact:externalTypeDefinitions"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="componentTypeDefinitionsRef" refer="ipxact:externalTypeDefinitionsKey">
+			<xs:selector xpath=".//ipxact:*"/>
+			<xs:field xpath="@typeDefinitions"/>
+		</xs:keyref>
+	</xs:element>
+	<xs:simpleType name="simpleClearboxType">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="signal"/>
+			<xs:enumeration value="pin"/>
+			<xs:enumeration value="interface"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="clearboxElementType">
+		<xs:annotation>
+			<xs:documentation>Defines a clear box reference point within the component.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="clearboxType" type="ipxact:simpleClearboxType">
+				<xs:annotation>
+					<xs:documentation>Indicates the type of the element. The pin and signal types refer to elements within the HDL description. The interface type refers to a group of signals addressed as a single unit.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="driveable" type="xs:boolean" default="false" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If true, indicates that the clear box element can be driven (e.g. have a new value forced into it).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/configurable.xsd
+++ b/ieee-1685-2022/configurable.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+</xs:schema>

--- a/ieee-1685-2022/constraints.xsd
+++ b/ieee-1685-2022/constraints.xsd
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+    <xs:include schemaLocation="commonStructures.xsd"/>
+    <xs:include schemaLocation="autoConfigure.xsd"/>
+    <xs:include schemaLocation="signalDrivers.xsd"/>
+    
+    <xs:simpleType name="cellFunctionValueType">
+        <xs:annotation>
+            <xs:documentation>Indicates legal cell function values.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="nand2"/>
+            <xs:enumeration value="buf"/>
+            <xs:enumeration value="inv"/>
+            <xs:enumeration value="mux21"/>
+            <xs:enumeration value="dff"/>
+            <xs:enumeration value="latch"/>
+            <xs:enumeration value="xor2"/>
+            <xs:enumeration value="other"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cellClassValueType">
+        <xs:annotation>
+            <xs:documentation>Indicates legal cell class values.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="combinational"/>
+            <xs:enumeration value="sequential"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cellStrengthValueType">
+        <xs:annotation>
+            <xs:documentation>Indicates legal cell strength values.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="low"/>
+            <xs:enumeration value="median"/>
+            <xs:enumeration value="high"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name="edgeValueType">
+        <xs:annotation>
+            <xs:documentation>Indicates legal values for edge specification attributes.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="rise"/>
+            <xs:enumeration value="fall"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="delayValueType">
+        <xs:annotation>
+            <xs:documentation>Indicates the type of delay value - minimum or maximum delay.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="min"/>
+            <xs:enumeration value="max"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="delayPercentageType">
+        <xs:annotation>
+            <xs:documentation>Type used to record percentage values.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:float">
+            <xs:minInclusive value="0.0"/>
+            <xs:maxInclusive value="100.0"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:complexType name="otherClocks">
+        <xs:annotation>
+            <xs:documentation>List of clocks associated with the component that are not associated with ports. Set the clockSource attribute on the clockDriver to indicate the source of a clock not associated with a particular component port.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="ipxact:otherClockDriver" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="cellSpecification">
+        <xs:annotation>
+            <xs:documentation>Used to provide a generic description of a technology library cell.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice>
+                <xs:element name="cellFunction">
+                    <xs:annotation>
+                        <xs:documentation>Defines a technology library cell in library independent fashion, based on specification of a cell function and strength.</xs:documentation>
+                    </xs:annotation>
+          				<xs:complexType>
+          				  <xs:simpleContent>
+          				    <xs:extension base="ipxact:cellFunctionValueType">
+          				      <xs:attribute name="other" type="xs:token"/>
+          				    </xs:extension>
+          				  </xs:simpleContent>
+          				</xs:complexType>
+                </xs:element>
+                <xs:element name="cellClass" type="ipxact:cellClassValueType">
+                    <xs:annotation>
+                        <xs:documentation>Defines a technology library cell in library independent fashion, based on specification of a cell class and strength.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:attribute name="cellStrength" type="ipxact:cellStrengthValueType">
+                <xs:annotation>
+                    <xs:documentation>Indicates the desired strength of the specified cell.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="timingConstraint">
+        <xs:annotation>
+            <xs:documentation>Defines a timing constraint for the associated port. The constraint is relative to the clock specified by the clockName attribute. The clockEdge indicates which clock edge the constraint is associated with (default is rising edge). The delayType attribute can be specified to further refine the constraint.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="ipxact:delayPercentageType">
+                    <xs:attribute name="clockEdge" type="ipxact:edgeValueType">
+                        <xs:annotation>
+                            <xs:documentation>Indicates the clock edge that a timing constraint is relative to.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="delayType" type="ipxact:delayValueType">
+                        <xs:annotation>
+                            <xs:documentation>Indicates the type of delay in a timing constraint - minimum or maximum.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="clockName" type="ipxact:portName" use="required">
+                        <xs:annotation>
+                            <xs:documentation>Indicates the name of the clock to which this constraint applies.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attributeGroup ref="ipxact:id.att"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="driveConstraint">
+        <xs:annotation>
+            <xs:documentation>Defines a constraint indicating how an input is to be driven. The preferred methodology is to specify a library cell in technology independent fashion. The implemention tool should assume that the associated port is driven by the specified cell, or that the drive strength of the input port is indicated by the specified resistance value.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="ipxact:cellSpecification"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="loadConstraint">
+        <xs:annotation>
+            <xs:documentation>Defines a constraint indicating the type of load on an output port.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="ipxact:cellSpecification"/>
+                <xs:element name="count" type="ipxact:unsignedPositiveIntExpression" default="3" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>Indicates how many loads of the specified cell are connected. If not present, 3 is assumed.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="constraintSet">
+        <xs:annotation>
+            <xs:documentation>Defines constraints that apply to a component port. If multiple constraintSet elements are used, each must have a unique value for the constraintSetId attribute.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:group ref="ipxact:nameGroupOptional"/>
+                <xs:element name="vector" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>The optional element vector specify the bits of a vector for which the constraints apply. The vaules of left and right must be within the range of the port. If the vector is not specified then the constraints apply to all the bits of the port.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="left" type="ipxact:unsignedIntExpression">
+                                <xs:annotation>
+                                    <xs:documentation>The optional elements left and right can be used to select a bit-slice of a vector. </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="right" type="ipxact:unsignedIntExpression">
+                                <xs:annotation>
+                                    <xs:documentation>The optional elements left and right can be used to select a bit-slice of a vector. </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="ipxact:driveConstraint" minOccurs="0"/>
+                <xs:element ref="ipxact:loadConstraint" minOccurs="0"/>
+                <xs:element ref="ipxact:timingConstraint" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="constraintSetId" type="xs:NMTOKEN" default="default">
+                <xs:annotation>
+                    <xs:documentation>Indicates a name for this set of constraints. Constraints are tied to a view using this name in the constraintSetRef element.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attributeGroup ref="ipxact:id.att"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="constraintSets">
+        <xs:annotation>
+            <xs:documentation>List of constraintSet elements for a component port.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="ipxact:constraintSet" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="constraintSetRef">
+        <xs:annotation>
+            <xs:documentation>A reference to a set of port constraints.</xs:documentation>
+        </xs:annotation>
+      	<xs:complexType>
+      	    <xs:sequence>
+          		<xs:element name="localName" type="xs:NMTOKEN"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+      	    </xs:sequence>
+      	    <xs:attributeGroup ref="ipxact:id.att"/>
+      	</xs:complexType>
+    </xs:element>
+    <xs:complexType name="abstractionDefPortConstraintsType">
+        <xs:annotation>
+            <xs:documentation>Defines constraints that apply to a wire type port in an abstraction definition. </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:sequence>
+                <xs:element ref="ipxact:timingConstraint" maxOccurs="unbounded"/>
+                <xs:element ref="ipxact:driveConstraint" minOccurs="0"/>
+                <xs:element ref="ipxact:loadConstraint" minOccurs="0"/>
+            </xs:sequence>
+            <xs:sequence>
+                <xs:element ref="ipxact:driveConstraint"/>
+                <xs:element ref="ipxact:loadConstraint" minOccurs="0"/>
+            </xs:sequence>
+            <xs:sequence>
+                <xs:element ref="ipxact:loadConstraint"/>
+            </xs:sequence>
+        </xs:choice>
+    </xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/design.xsd
+++ b/ieee-1685-2022/design.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="subInstances.xsd"/>
+	<xs:include schemaLocation="model.xsd"/>
+	<xs:include schemaLocation="port.xsd"/>
+	<xs:element name="design">
+		<xs:annotation>
+			<xs:documentation>Root element for a platform design.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:element ref="ipxact:componentInstances" minOccurs="0"/>
+				<xs:element ref="ipxact:interconnections" minOccurs="0"/>
+				<xs:element ref="ipxact:adHocConnections" minOccurs="0"/>
+				<xs:element ref="ipxact:choices" minOccurs="0"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:assertions" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:key name="designComponentInstanceKey">
+			<xs:selector xpath="ipxact:componentInstances/ipxact:componentInstance"/>
+			<xs:field xpath="ipxact:instanceName"/>
+		</xs:key>
+		<xs:keyref name="designInterconnectionActiveInstanceRef" refer="ipxact:designComponentInstanceKey">
+			<xs:selector xpath="ipxact:interconnections/ipxact:interconnection/ipxact:activeInterface"/>
+			<xs:field xpath="@componentInstanceRef"/>
+		</xs:keyref>
+		<xs:keyref name="designAdhocConnectionActiveInstanceRef" refer="ipxact:designComponentInstanceKey">
+			<xs:selector xpath="ipxact:adHocConnections/ipxact:adHocConnection/ipxact:portReferences/ipxact:internalPortReference"/>
+			<xs:field xpath="@componentInstanceRef"/>
+		</xs:keyref>
+		<xs:unique name="designInterconnectionName">
+			<xs:selector xpath=".//ipxact:interconnection|.//ipxact:monitorInterconnection"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+		<xs:unique name="designAdHocName">
+			<xs:selector xpath=".//ipxact:adHocConnection"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+		<xs:unique name="designParameterUnique">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:key name="designChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:keyref name="designChoiceRef" refer="ipxact:designChoiceKey">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/designConfig.xsd
+++ b/ieee-1685-2022/designConfig.xsd
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="model.xsd"/>
+	<xs:include schemaLocation="subInstances.xsd"/>
+	<xs:element name="designConfiguration">
+		<xs:annotation>
+			<xs:documentation>Top level element for describing the current configuration of a design. Does not describe instance parameterization</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:element name="designRef" type="ipxact:libraryRefType" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The design to which this configuration applies</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="generatorChainConfiguration" type="ipxact:configurableLibraryRefType" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Contains the configurable information associated with a generatorChain and its generators. Note that configurable information for generators associated with components is stored in the design file.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="interconnectionConfiguration" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Contains the information about the abstractors required to cross between two interfaces at with different abstractionDefs.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="interconnectionRef" type="xs:Name">
+								<xs:annotation>
+									<xs:documentation>Reference to the interconnection name, monitor interconnection name or possibly a hierConnection interfaceName in a design file.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="abstractorInstances" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>List of abstractor-instances for this interconnection. Multiple abstractor-instances elements may be present for a 1-to-many (broadcast) interconnection. In that case, the optional interfaceRef elements must reference non-overlapping interfaces from the 'many' side of the interconnection.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="interfaceRef" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Defines the broadcast endpoint to which this chain of abstractors applies.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence minOccurs="0">
+													<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+												</xs:sequence>
+												<xs:attribute name="componentRef" type="xs:Name" use="required">
+													<xs:annotation>
+														<xs:documentation>Reference to a component instance nane.</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+												<xs:attribute name="busRef" type="xs:Name" use="required">
+													<xs:annotation>
+														<xs:documentation>Reference to a component bus interface name.</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+												<xs:attributeGroup ref="ipxact:id.att"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="abstractorInstance" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Element to hold a the abstractor reference, the configuration and viewName. If multiple elements are present then the order is the order in which the abstractors should be chained together.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="instanceName" type="xs:Name">
+														<xs:annotation>
+															<xs:documentation>Instance name for the abstractor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element ref="ipxact:displayName" minOccurs="0"/>
+													<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+													<xs:element ref="ipxact:description" minOccurs="0"/>
+													<xs:element name="abstractorRef" type="ipxact:configurableLibraryRefType">
+														<xs:annotation>
+															<xs:documentation>Abstractor reference</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="viewName" type="xs:Name">
+														<xs:annotation>
+															<xs:documentation>The name of the active view for this abstractor instance.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+												<xs:attributeGroup ref="ipxact:id.att"/>
+											</xs:complexType>
+										</xs:element>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:unique name="designConfigInterfaceRefUnique">
+						<xs:selector xpath="ipxact:abstractorInstances/ipxact:interfaceRef"/>
+						<xs:field xpath="@componentRef"/>
+						<xs:field xpath="@busRef"/>
+					</xs:unique>
+				</xs:element>
+				<xs:element name="viewConfiguration" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Contains the active views for each instance in the design</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="ipxact:instanceName"/>
+							<xs:element name="view">
+								<xs:annotation>
+									<xs:documentation>The selected view for the instance.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="ipxact:configurableElementValues" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Parameter values to set in the selected configuredView.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="viewRef" type="xs:NMTOKEN" use="required"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:choices" minOccurs="0"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:assertions" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:key name="designConfigViewInstanceKey">
+			<xs:selector xpath="ipxact:viewConfiguration"/>
+			<xs:field xpath="ipxact:instanceName"/>
+		</xs:key>
+		<xs:key name="designConfigAbstractorInstanceKey">
+			<xs:selector xpath="ipxact:interconnectionConfiguration/ipxact:abstractorInstances/ipxact:abstractorInstance"/>
+			<xs:field xpath="ipxact:instanceName"/>
+		</xs:key>
+		<xs:key name="designConfigInterconnectionRefKey">
+			<xs:selector xpath="ipxact:interconnectionConfiguration"/>
+			<xs:field xpath="ipxact:interconnectionRef"/>
+		</xs:key>
+		<xs:key name="designConfigGeneratorChainRefKey">
+			<xs:selector xpath="ipxact:generatorChainConfiguration"/>
+			<xs:field xpath="@vendor"/>
+			<xs:field xpath="@library"/>
+			<xs:field xpath="@name"/>
+			<xs:field xpath="@version"/>
+		</xs:key>
+		<xs:unique name="designConfigParameterUnique">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:key name="designConfigChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:keyref name="designConfigChoiceRef" refer="ipxact:designConfigChoiceKey">
+			<xs:selector xpath="ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/file.xsd
+++ b/ieee-1685-2022/file.xsd
@@ -1,0 +1,467 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="fileType.xsd"/>
+	<xs:element name="file">
+		<xs:annotation>
+			<xs:documentation>IP-XACT reference to a file or directory.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="name" type="ipxact:ipxactURI">
+					<xs:annotation>
+						<xs:documentation>Path to the file or directory. If this path is a relative path, then it is relative to the containing XML file. </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:fileType" maxOccurs="unbounded"/>
+				<xs:element name="isStructural" type="xs:boolean" default="false" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Indicates that the current file is purely structural.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="isIncludeFile" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Indicate that the file is include file.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:boolean">
+								<xs:attribute name="externalDeclarations" type="xs:boolean" default="false">
+									<xs:annotation>
+										<xs:documentation>the File contains some declarations that are needed in top file</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="logicalName" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Logical name for this file or directory e.g. VHDL library name.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="default" type="xs:boolean" use="optional" default="false">
+									<xs:annotation>
+										<xs:documentation>The logical name shall only be used as a default and another process may override this name.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="exportedName" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Defines exported names that can be accessed externally, e.g. exported function names from a C source file.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="buildCommand" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Command and flags used to build derived files from the sourceName files. If this element is present, the command and/or flags used to to build the file will override or augment any default builders at a higher level.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="command" type="ipxact:stringExpression" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Command used to build this file.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="flags" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Flags given to the build command when building this file. If the optional attribute "append" is "true", this string will be appended to any existing flags, otherwise these flags will replace any existing default flags.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="ipxact:stringExpression">
+											<xs:attribute name="append" type="xs:boolean" use="optional">
+												<xs:annotation>
+													<xs:documentation>"true" indicates that the flags shall be appended to any existing flags, "false"indicates these flags will replace any existing default flags.</xs:documentation>
+												</xs:annotation>
+											</xs:attribute>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="replaceDefaultFlags" type="ipxact:unsignedBitExpression" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>If true, the value of the sibling element "flags" should replace any default flags specified at a more global level. If this is true and the sibling element "flags" is empty or missing, this has the effect of clearing any default flags.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="targetName" type="ipxact:ipxactURI" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Pathname to the file that is derived (built) from the source file.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:dependency" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="define" type="ipxact:nameValuePairType" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specifies define symbols that are used in the source file.  The ipxact:name element gives the name to be defined and the text content of the ipxact:value element holds the value.  This element supports full configurability.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="imageType" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Relates the current file to a certain executable image type in the design.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="description" type="xs:string" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>String for describing this file to users</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="fileId" type="xs:token">
+				<xs:annotation>
+					<xs:documentation>Unique ID for this file, referenced in fileSet/function/fileRef</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:any.att"/>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fileSet" type="ipxact:fileSetType">
+		<xs:annotation>
+			<xs:documentation>This element specifies a list of unique pathnames to files and directories. It may also include build instructions for the files. If compilation order is important, e.g. for VHDL files, the files have to be provided in compilation order.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="executableImage">
+		<xs:annotation>
+			<xs:documentation>Specifies an executable software image to be loaded into a processors address space. The format of the image is not specified. It could, for example, be an ELF loadfile, or it could be raw binary or ascii hex data for loading directly into a memory model instance.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroup"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Additional information about the load module, e.g. stack base addresses, table addresses, etc.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="languageTools" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Default commands and flags for software language tools needed to build the executable image.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="fileBuilder" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>A generic placeholder for any file builder like compilers and assemblers.  It contains the file types to which the command should be applied, and the flags to be used with that command.  </xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="ipxact:fileType"/>
+										<xs:element name="command" type="ipxact:stringExpression">
+											<xs:annotation>
+												<xs:documentation>Default command used to build files of the specified fileType. </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="flags" type="ipxact:stringExpression" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Flags given to the build command when building files of this type.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="replaceDefaultFlags" type="ipxact:unsignedBitExpression" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>If true, replace any default flags value with the value in the sibling flags element. Otherwise, append the contents of the sibling flags element to any default flags value.
+
+If the value is true and the "flags" element is empty or missing, this will have the result of clearing any default flags value.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:sequence minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>If a languageTools element contains a linkerFlags element or a linkerCommandFile element, it shall also contain a linker element.</xs:documentation>
+								</xs:annotation>
+								<xs:element name="linker" type="ipxact:stringExpression" minOccurs="1"/>
+								<xs:choice>
+									<xs:sequence minOccurs="1">
+										<xs:element name="linkerFlags" type="ipxact:stringExpression" minOccurs="1"/>
+										<xs:element ref="ipxact:linkerCommandFile" minOccurs="0"/>
+									</xs:sequence>
+									<xs:element ref="ipxact:linkerCommandFile" minOccurs="1"/>
+								</xs:choice>
+							</xs:sequence>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="fileSetRefGroup" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Contains a group of file set references that indicates the set of file sets complying with the tool set of the current executable image.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="ipxact:fileSetRef" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="imageId" type="xs:token" use="required">
+				<xs:annotation>
+					<xs:documentation>Unique ID for the executableImage, referenced in fileSet/function/fileRef</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="imageType" type="xs:Name" use="optional">
+				<xs:annotation>
+					<xs:documentation>Open element to describe the type of image. The contents is model and/or generator specific.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="linkerCommandFile">
+		<xs:annotation>
+			<xs:documentation>Specifies a linker command file.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="name" type="ipxact:stringExpression">
+					<xs:annotation>
+						<xs:documentation>Linker command file name.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="commandLineSwitch" type="ipxact:stringExpression">
+					<xs:annotation>
+						<xs:documentation>The command line switch to specify the linker command file.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="enable" type="ipxact:unsignedBitExpression">
+					<xs:annotation>
+						<xs:documentation>Specifies whether to generate and enable the linker command file.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:generatorRef" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fileSetRef">
+		<xs:annotation>
+			<xs:documentation>A reference to a fileSet.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="localName" type="xs:Name">
+					<xs:annotation>
+						<xs:documentation>Refers to a fileSet defined within this description.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="dependency">
+		<xs:annotation>
+			<xs:documentation>Specifies a location on which  files or fileSets may be dependent. Typically, this would be a directory that would contain included files.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:ipxactURI">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fileSets">
+		<xs:annotation>
+			<xs:documentation>List of file sets associated with component.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:fileSet" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="fileBuilderType">
+		<xs:sequence>
+			<xs:element ref="ipxact:fileType"/>
+			<xs:element name="command" type="ipxact:stringExpression" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Default command used to build files of the specified fileType. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="flags" type="ipxact:stringExpression" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Flags given to the build command when building files of this type.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="replaceDefaultFlags" type="ipxact:unsignedBitExpression" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If true, replace any default flags value with the value in the sibling flags element. Otherwise, append the contents of the sibling flags element to any default flags value.
+
+If the value is true and the "flags" element is empty or missing, this will have the result of clearing any default flags value.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:simpleType name="returnTypeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="void"/>
+			<xs:enumeration value="int"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="fileSetType">
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="group" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Identifies this filleSet as belonging to a particular group or having a particular purpose. Examples might be "diagnostics", "boot", "application", "interrupt", "deviceDriver", etc.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:Name">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:file" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="defaultFileBuilder" type="ipxact:fileBuilderType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Default command and flags used to build derived files from the sourceName files in this file set.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:dependency" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="function" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Generator information if this file set describes a function. For example, this file set may describe diagnostics for which the DE can generate a diagnostics driver.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="entryPoint" type="xs:Name" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Optional name for the function.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="fileRef" type="xs:token">
+							<xs:annotation>
+								<xs:documentation>A reference to the file that contains the entry point function.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="returnType" type="ipxact:returnTypeType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Function return type. Possible values are void and int.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="argument" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Arguments passed in when the function is called. Arguments are passed in order.
+
+This is an extension of the name-value pair which includes the data type in the ipxact:dataType attribute.  The argument name is in the ipxact:name element and its value is in the ipxact:value element.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:complexContent>
+									<xs:extension base="ipxact:nameValuePairType">
+										<xs:attribute name="dataType" type="ipxact:dataTypeType" use="required">
+											<xs:annotation>
+												<xs:documentation>The data type of the argument as pertains to the language. Example: "int", "double", "char *".</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:complexContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="disabled" type="ipxact:unsignedBitExpression" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Specifies if the SW function is enabled. If not present the function is always enabled.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="sourceFile" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Location information for the source file of this function.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="sourceName" type="ipxact:ipxactURI">
+										<xs:annotation>
+											<xs:documentation>Source file for the boot load.  Relative names are searched for in the project directory and the source of the component directory.
+    </xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element ref="ipxact:fileType"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="replicate" type="xs:boolean" default="false">
+						<xs:annotation>
+							<xs:documentation>If true directs the generator to compile a separate object module for each instance of the component in the design. If false (default) the function will be called with different arguments for each instance.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:simpleType name="dataTypeType">
+		<xs:annotation>
+			<xs:documentation>Enumerates C argument data types.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="int"/>
+			<xs:enumeration value="unsigned int"/>
+			<xs:enumeration value="long"/>
+			<xs:enumeration value="unsigned long"/>
+			<xs:enumeration value="float"/>
+			<xs:enumeration value="double"/>
+			<xs:enumeration value="char *"/>
+			<xs:enumeration value="void *"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="generatorRef">
+		<xs:annotation>
+			<xs:documentation>A reference to a generator element.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/fileType.xsd
+++ b/ieee-1685-2022/fileType.xsd
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:simpleType name="simpleFileType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="cSource"/>
+			<xs:enumeration value="cppSource"/>
+			<xs:enumeration value="asmSource"/>
+			<xs:enumeration value="vhdlSource"/>
+			<xs:enumeration value="vhdlSource-87"/>
+			<xs:enumeration value="vhdlSource-93"/>
+			<xs:enumeration value="vhdlSource-2002"/>
+			<xs:enumeration value="vhdlSource-2008"/>
+			<xs:enumeration value="verilogSource"/>
+			<xs:enumeration value="verilogSource-95"/>
+			<xs:enumeration value="verilogSource-2001"/>
+			<xs:enumeration value="verilogSource-2005"/>
+			<xs:enumeration value="swObject"/>
+			<xs:enumeration value="swObjectLibrary"/>
+			<xs:enumeration value="vhdlBinaryLibrary"/>
+			<xs:enumeration value="verilogBinaryLibrary"/>
+			<xs:enumeration value="unelaboratedHdl"/>
+			<xs:enumeration value="executableHdl"/>
+			<xs:enumeration value="systemVerilogSource"/>
+			<xs:enumeration value="systemVerilogSource-3.0"/>
+			<xs:enumeration value="systemVerilogSource-3.1"/>
+			<xs:enumeration value="systemVerilogSource-3.1a"/>
+			<xs:enumeration value="systemVerilogSource-2009"/>
+			<xs:enumeration value="systemVerilogSource-2012"/>
+			<xs:enumeration value="systemVerilogSource-2017"/>
+			<xs:enumeration value="systemCSource"/>
+			<xs:enumeration value="systemCSource-2.0"/>
+			<xs:enumeration value="systemCSource-2.0.1"/>
+			<xs:enumeration value="systemCSource-2.1"/>
+			<xs:enumeration value="systemCSource-2.2"/>
+			<xs:enumeration value="systemCSource-2.3"/>
+			<xs:enumeration value="systemCBinaryLibrary"/>
+			<xs:enumeration value="veraSource"/>
+			<xs:enumeration value="eSource"/>
+			<xs:enumeration value="perlSource"/>
+			<xs:enumeration value="tclSource"/>
+			<xs:enumeration value="OVASource"/>
+			<xs:enumeration value="SVASource"/>
+			<xs:enumeration value="pslSource"/>
+			<xs:enumeration value="SDC"/>
+			<xs:enumeration value="vhdlAmsSource"/>
+			<xs:enumeration value="verilogAmsSource"/>
+			<xs:enumeration value="systemCAmsSource"/>
+			<xs:enumeration value="libertySource"/>
+			<xs:enumeration value="spiceSource"/>
+			<xs:enumeration value="systemRDL"/>
+			<xs:enumeration value="systemRDL-1.0"/>
+			<xs:enumeration value="systemRDL-2.0"/>
+			<xs:enumeration value="user"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="fileType">
+		<xs:annotation>
+			<xs:documentation>Enumerated file types known by IP-XACT.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:simpleFileType">
+					<xs:attribute name="user" type="xs:string"/>
+					<xs:attribute name="libext" type="xs:string"/>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/generator.xsd
+++ b/ieee-1685-2022/generator.xsd
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="file.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:element name="generatorChain">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:choice maxOccurs="unbounded">
+					<xs:element name="generatorChainSelector">
+						<xs:annotation>
+							<xs:documentation>Select other generator chain files for inclusion into this chain. The boolean attribute "unique" (default false) specifies that only a single generator is valid in this context. If more that one generator is selected based on the selection criteria, DE will prompt the user to resolve to a single generator.</xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+							<xs:choice>
+								<xs:element ref="ipxact:groupSelector"/>
+								<xs:element name="generatorChainRef" type="ipxact:configurableLibraryRefType">
+									<xs:annotation>
+										<xs:documentation>Select another generator chain using the unique identifier of this generator chain.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+							</xs:choice>
+							<xs:attribute name="unique" type="xs:boolean" use="optional" default="false">
+								<xs:annotation>
+									<xs:documentation>Specifies that only a single generator is valid in this context. If more that one generator is selcted based on the selection criteria, DE will prompt the user to resolve to a single generator.</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="componentGeneratorSelector" type="ipxact:generatorSelectorType">
+						<xs:annotation>
+							<xs:documentation>Selects generators declared in components of the current design for inclusion into this generator chain.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="ipxact:generator"/>
+				</xs:choice>
+				<xs:element name="chainGroup" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Identifies this generator chain as belonging to the named group. This is used by other generator chains to select this chain for programmatic inclusion.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:choices" minOccurs="0"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:assertions" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="hidden" type="xs:boolean" use="optional" default="false">
+				<xs:annotation>
+					<xs:documentation>If this attribute is true then the generator should not be presented to the user, it may be part of a chain and has no useful meaning when invoked standalone.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:unique name="generatorParameterUnique">
+			<xs:selector xpath=".//ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:key name="generatorConfigChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice/ipxact:name"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:keyref name="generatorConfigChoiceRef" refer="ipxact:generatorConfigChoiceKey">
+			<xs:selector xpath=".//ipxact:parameters/ipxact:parameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+	</xs:element>
+	<xs:element name="generator">
+		<xs:annotation>
+			<xs:documentation>Specifies a set of generators.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ipxact:generatorType"/>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="componentGenerator" type="ipxact:instanceGeneratorType">
+		<xs:annotation>
+			<xs:documentation>Specifies a set of component generators. The scope attribute applies to component generators and specifies whether the generator should be run for each instance of the entity (or module) or just once for all instances of the entity.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="abstractorGenerator" type="ipxact:instanceGeneratorType">
+		<xs:annotation>
+			<xs:documentation>Specifies a set of abstractor generators. The scope attribute applies to abstractor generators and specifies whether the generator should be run for each instance of the entity (or module) or just once for all instances of the entity.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="groupSelector">
+		<xs:annotation>
+			<xs:documentation>Specifies a set of group names used to select subsequent generators. The attribute "multipleGroupOperator" specifies the OR or AND selection operator if there is more than one group name (default=OR).</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="name" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specifies a generator group name or a generator chain group name to be selected for inclusion in the generator chain.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="multipleGroupSelectionOperator" use="optional" default="or">
+				<xs:annotation>
+					<xs:documentation>Specifies the OR or AND selection operator if there is more than one group name.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:Name">
+						<xs:enumeration value="and"/>
+						<xs:enumeration value="or"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="phase" type="ipxact:realExpression">
+		<xs:annotation>
+			<xs:documentation>This is an non-negative floating point number that is used to sequence when a generator is run. The generators are run in order starting with zero. There may be multiple generators with the same phase number. In this case, the order should not matter with respect to other generators at the same phase. If no phase number is given the generator will be considered in the "last" phase and these generators will be run in the order in which they are encountered while processing generator elements.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="instanceGeneratorType">
+		<xs:complexContent>
+			<xs:extension base="ipxact:generatorType">
+				<xs:sequence>
+					<xs:element name="group" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>An identifier to specify the generator group. This is used by generator chains for selecting which generators to run.</xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+							<xs:simpleContent>
+								<xs:extension base="xs:Name">
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:extension>
+							</xs:simpleContent>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+				<xs:attribute name="scope" use="optional" default="instance">
+					<xs:annotation>
+						<xs:documentation>The scope attribute applies to component generators and specifies whether the generator should be run for each instance of the entity (or module) or just once for all instances of the entity.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="instance"/>
+							<xs:enumeration value="entity"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="generatorSelectorType">
+		<xs:sequence>
+			<xs:element ref="ipxact:groupSelector"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="componentGenerators">
+		<xs:annotation>
+			<xs:documentation>List of component generators.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:componentGenerator" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="abstractorGenerators">
+		<xs:annotation>
+			<xs:documentation>List of abstractor generators.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:abstractorGenerator" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="apiType">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="TGI_2009"/>
+			<xs:enumeration value="TGI_2014_BASE"/>
+			<xs:enumeration value="TGI_2014_EXTENDED"/>
+			<xs:enumeration value="TGI_2022_BASE"/>
+			<xs:enumeration value="TGI_2022_EXTENDED"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="transportMethodType">
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="file"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="generatorType">
+		<xs:annotation>
+			<xs:documentation>Types of generators</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element ref="ipxact:phase" minOccurs="0"/>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element name="apiType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indicates the type of API used by the generator. Valid value are TGI_2009, TGI_2014_BASE, TGI_2014_EXTENDED, TGI_2022_BASE, TGI_2022_EXTENDED, and none. If this element is not present, TGI_2022_BASE is assumed. The type TGI_2009 indicates a generator using the 1685-2009 version of the TGI API. The types TGI_2014_BASE and TGI_2014_EXTENDED indicate a generator using the 1685-2014 version of the TGI API. Types TGI_2009, TGI_2014_BASE, and TGI_2014_EXTENDED are not part of the 1685-2022 version of the standard and may not be supported by Design Environments</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="ipxact:apiType">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="apiService" default="SOAP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Communication Mechanism. Can be one of SOAP or REST (defaults to SOAP)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="SOAP"/>
+						<xs:enumeration value="REST"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="transportMethods" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="transportMethod">
+							<xs:annotation>
+								<xs:documentation>Defines a SOAP transport protocol other than HTTP which is supported by this generator. The only other currently supported protocol is 'file'.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="ipxact:transportMethodType">
+										<xs:attributeGroup ref="ipxact:id.att"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="generatorExe" type="ipxact:ipxactURI">
+				<xs:annotation>
+					<xs:documentation>The pathname to the executable file that implements the generator</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="hidden" type="xs:boolean" use="optional" default="false">
+			<xs:annotation>
+				<xs:documentation>If this attribute is true then the generator should not be presented to the user, it may be part of a chain and has no useful meaning when invoked standalone.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/identifier.xsd
+++ b/ieee-1685-2022/identifier.xsd
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:include schemaLocation="subInstances.xsd"/>
+	<xs:group name="baseIdentifier">
+		<xs:annotation>
+			<xs:documentation>Base IP-XACT identifier group. Identify an IP-XACT document by its by vendor, library and name.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence/>
+	</xs:group>
+	<xs:group name="versionedIdentifier">
+		<xs:annotation>
+			<xs:documentation>This group of elements identifies a top level item (e.g. a component or a bus definition)  with vendor, library, name and a version number. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vendor" type="xs:Name">
+				<xs:annotation>
+					<xs:documentation>Name of the vendor who supplies this file.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="library" type="xs:Name">
+				<xs:annotation>
+					<xs:documentation>Name of the logical library this element belongs to.  </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="name" type="xs:NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>The name of the object.  </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="version" type="xs:NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Indicates the version of the named element.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="documentNameGroup">
+		<xs:annotation>
+			<xs:documentation>Base IP-XACT document reference type. Contains vendor, library, name and version attributes.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:versionedIdentifier"/>
+			<xs:element name="displayName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Name for display purposes. Typically a few words providing a more detailed and/or user-friendly name than the vlnv.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:attributeGroup name="libraryRefGroup">
+		<xs:annotation>
+			<xs:documentation>Base IP-XACT document reference.  Contains vendor, library, name and version attributes.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="vendor" type="xs:Name" use="required"/>
+		<xs:attribute name="library" type="xs:Name" use="required"/>
+		<xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+		<xs:attribute name="version" type="xs:NMTOKEN" use="required"/>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:attributeGroup>
+	<xs:complexType name="libraryRefType">
+		<xs:annotation>
+			<xs:documentation>Base IP-XACT document reference type. Contains vendor, library, name and version attributes.</xs:documentation>
+		</xs:annotation>
+		<xs:attributeGroup ref="ipxact:libraryRefGroup">
+			<xs:annotation>
+				<xs:documentation>Base IP-XACT document reference.  Contains vendor, library, name and version attributes.</xs:documentation>
+			</xs:annotation>
+		</xs:attributeGroup>
+	</xs:complexType>
+	<xs:complexType name="configurableLibraryRefType">
+		<xs:annotation>
+			<xs:documentation>Base IP-XACT document reference type for configurable top-level objects. Contains vendor, library, name and version attributes along with configurable element values.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:configurableElementValues" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:libraryRefGroup">
+			<xs:annotation>
+				<xs:documentation>Base IP-XACT document reference.  Contains vendor, library, name and version attributes.</xs:documentation>
+			</xs:annotation>
+		</xs:attributeGroup>
+	</xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/index.xsd
+++ b/ieee-1685-2022/index.xsd
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="busDefinition.xsd"/>
+	<xs:include schemaLocation="component.xsd"/>
+	<xs:include schemaLocation="design.xsd"/>
+	<xs:include schemaLocation="designConfig.xsd"/>
+	<xs:include schemaLocation="abstractionDefinition.xsd"/>
+	<xs:include schemaLocation="catalog.xsd"/>
+	<xs:include schemaLocation="abstractor.xsd"/>
+	<xs:include schemaLocation="typeDefinitions.xsd"/>
+	<!-- <xs:include schemaLocation="memoryMapDefinition.xsd"/> -->
+	<!-- <xs:include schemaLocation="addressBlockDefinition.xsd"/> -->
+	<!-- <xs:include schemaLocation="registerFileDefinition.xsd"/> -->
+	<!-- <xs:include schemaLocation="registerDefinition.xsd"/> -->
+	<!-- <xs:include schemaLocation="fieldDefinition.xsd"/> -->
+	<!-- <xs:include schemaLocation="enumerationDefinition.xsd"/> -->
+	<xs:group name="IPXACTDocumentTypes">
+		<xs:annotation>
+			<xs:documentation>This IP-XACT schema documentation is part of the IP-XACT standard deliverables. The diagrams in this documentation represent the relationships between elements of the schema together with their attributes and expected values. Valid IP-XACT XML files must have a top-level type that is one of the elements listed here.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element ref="ipxact:busDefinition">
+				<xs:annotation>
+					<xs:documentation>To define all elements and attributes supported when defining a bus.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:abstractionDefinition"/>
+			<!--			<xs:element ref="ipxact:memoryMapDefinition"/>
+			<xs:element ref="ipxact:addressBlockDefinition"/>
+			<xs:element ref="ipxact:registerFileDefinition"/>
+			<xs:element ref="ipxact:registerDefinition"/>
+			<xs:element ref="ipxact:fieldDefinition"/>
+			<xs:element ref="ipxact:enumerationDefinition"/>
+-->
+			<xs:element ref="ipxact:component">
+				<xs:annotation>
+					<xs:documentation>To define all elements and attributes supported when defining a component.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:abstractor"/>
+			<xs:element ref="ipxact:design">
+				<xs:annotation>
+					<xs:documentation>To define all elements and attributes supported when defining a design and its configured components</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:generatorChain">
+				<xs:annotation>
+					<xs:documentation>To define all elements and attributes supported for defining generator chains.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:designConfiguration"/>
+			<xs:element ref="ipxact:catalog"/>
+			<xs:element ref="ipxact:typeDefinitions"/>
+		</xs:choice>
+	</xs:group>
+</xs:schema>

--- a/ieee-1685-2022/memoryMap.xsd
+++ b/ieee-1685-2022/memoryMap.xsd
@@ -1,0 +1,1862 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="file.xsd"/>
+	<xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:simpleType name="accessType">
+		<xs:annotation>
+			<xs:documentation>The read/write accessability of an addess block.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="read-only"/>
+			<xs:enumeration value="write-only"/>
+			<xs:enumeration value="read-write"/>
+			<xs:enumeration value="writeOnce"/>
+			<xs:enumeration value="read-writeOnce"/>
+			<xs:enumeration value="no-access"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="sharedType">
+		<xs:annotation>
+			<xs:documentation>The sharedness of the memoryMap content.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="yes"/>
+			<xs:enumeration value="no"/>
+			<xs:enumeration value="undefined"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="bankAlignmentType">
+		<xs:annotation>
+			<xs:documentation>'serial' or 'parallel' bank alignment.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="serial"/>
+			<xs:enumeration value="parallel"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="usageType">
+		<xs:annotation>
+			<xs:documentation>Describes the usage of an address block.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="memory">
+				<xs:annotation>
+					<xs:documentation>Denotes an address range that can be used for read-write or read-only data storage.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="register">
+				<xs:annotation>
+					<xs:documentation>Denotes an address block that is used to communicate with hardware.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="reserved">
+				<xs:annotation>
+					<xs:documentation>Denotes an address range that must remain unoccupied.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="addressBankType">
+		<xs:annotation>
+			<xs:documentation>Top level bank the specify an address</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ipxact:addressSpecifier"/>
+			<xs:choice>
+				<xs:element name="bankDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:bankBase"/>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="bankAlignment" type="ipxact:bankAlignmentType" use="required">
+			<xs:annotation>
+				<xs:documentation>Describes whether this bank's blocks are aligned in 'parallel' or 'serial'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="addressBankDefinitionType">
+		<xs:annotation>
+			<xs:documentation>Top level bank the specify an address</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ipxact:addressSpecifier"/>
+			<xs:choice>
+				<xs:element name="bankDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:bankDefinitionBase"/>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="bankAlignment" type="ipxact:bankAlignmentType" use="required">
+			<xs:annotation>
+				<xs:documentation>Describes whether this bank's blocks are aligned in 'parallel' or 'serial'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="localAddressBankType">
+		<xs:annotation>
+			<xs:documentation>Top level bank the specify an address</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ipxact:addressSpecifier"/>
+			<xs:group ref="ipxact:localBankBase"/>
+		</xs:sequence>
+		<xs:attribute name="bankAlignment" type="ipxact:bankAlignmentType" use="required">
+			<xs:annotation>
+				<xs:documentation>Describes whether this bank's blocks are aligned in 'parallel' or 'serial'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="addressBlockType">
+		<xs:annotation>
+			<xs:documentation>Top level address block that specify an address</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:slicedAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:array" minOccurs="0"/>
+			<xs:group ref="ipxact:addressSpecifier"/>
+			<xs:choice>
+				<xs:element name="addressBlockDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:addressBlockDefinitionGroup"/>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attribute name="misalignmentAllowed" type="xs:boolean" use="optional" default="true">
+			<xs:annotation>
+				<xs:documentation>If true, register alignment is not restricted to register size. Defaults to false.           	</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="addrSpaceRefType">
+		<xs:annotation>
+			<xs:documentation>Base type for an element which references an address space.  Reference is kept in an attribute rather than the text value, so that the type may be extended with child elements if necessary.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="addressSpaceRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>A reference to a unique address space.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="memoryMapRefType">
+		<xs:annotation>
+			<xs:documentation>Base type for an element which references an memory map.  Reference is kept in an attribute rather than the text value, so that the type may be extended with child elements if necessary.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="modeRef" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:annotation>
+						<xs:documentation>A reference to a mode.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleContent>
+						<xs:extension base="xs:Name">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="memoryMapRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>A reference to a unique memory map.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="bankedBankType">
+		<xs:annotation>
+			<xs:documentation>Banks nested inside a bank do not specify address.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="bankDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:bankBase"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="bankAlignment" type="ipxact:bankAlignmentType" use="required"/>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="bankedDefinitionBankType">
+		<xs:annotation>
+			<xs:documentation>Banks nested inside a bank do not specify address.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="bankDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:bankDefinitionBase"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="bankAlignment" type="ipxact:bankAlignmentType" use="required"/>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="localBankedBankType">
+		<xs:annotation>
+			<xs:documentation>Banks nested inside a bank do not specify address.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ipxact:localBankBase"/>
+		</xs:sequence>
+		<xs:attribute name="bankAlignment" type="ipxact:bankAlignmentType" use="required"/>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="bankedBlockType">
+		<xs:annotation>
+			<xs:documentation>Address blocks inside a bank do not specify address.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:slicedAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ipxact:blockSize"/>
+			<xs:group ref="ipxact:addressBlockExtensions"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="bankedSubspaceType">
+		<xs:annotation>
+			<xs:documentation>Subspace references inside banks do not specify an address.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupOptional"/>
+			<xs:element ref="ipxact:parameters" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Any parameters that may apply to the subspace reference.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="initiatorRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>For subspaceMap elements, this attribute identifies the initiator that contains the address space to be mapped.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="fieldType">
+		<xs:annotation>
+			<xs:documentation>A field within a register</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence minOccurs="1" maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:slicedAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="array" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:dim" maxOccurs="unbounded"/>
+						<xs:element ref="ipxact:bitStride" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="bitOffset" type="ipxact:unsignedIntExpression">
+				<xs:annotation>
+					<xs:documentation>Offset of this field's bit 0 from bit 0 of the register.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="fieldDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:fieldDefinitionGroup"/>
+			</xs:choice>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:group name="memoryMap">
+		<xs:annotation>
+			<xs:documentation>A group elements for a memoryMap</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element ref="ipxact:addressBlock"/>
+			<xs:element ref="ipxact:bank"/>
+			<xs:element ref="ipxact:subspaceMap"/>
+		</xs:choice>
+	</xs:group>
+	<xs:group name="memoryMapDefinitionGroup">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element ref="ipxact:addressBlock" minOccurs="0"/>
+				<xs:element ref="ipxact:bank" minOccurs="0"/>
+			</xs:choice>
+			<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+			<xs:element name="shared" type="ipxact:sharedType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>When the value is 'yes', the contents of the memoryMap are shared by all the references to this memoryMap, when the value is 'no' the contents of the memoryMap is not shared and when the value is 'undefined' (default) the sharing of the memoryMap is undefined.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="memoryMapDefinitionTypeGroup">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="ipxact:addressBlock"/>
+				<xs:element name="bank" type="ipxact:addressBankDefinitionType">
+					<xs:annotation>
+						<xs:documentation>An addressable bank of blocks within a bank definition.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="addressBankedDefinition2MMKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="memoryRemap" type="ipxact:memoryRemapDefinitionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+			<xs:element name="shared" type="ipxact:sharedType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>When the value is 'yes', the contents of the memoryMap are shared by all the references to this memoryMap, when the value is 'no' the contents of the memoryMap is not shared and when the value is 'undefined' (default) the sharing of the memoryMap is undefined.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="memoryMapGroup">
+		<xs:sequence>
+			<xs:group ref="ipxact:memoryMap" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:memoryRemap" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+			<xs:element name="shared" type="ipxact:sharedType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>When the value is 'yes', the contents of the memoryMap are shared by all the references to this memoryMap, when the value is 'no' the contents of the memoryMap is not shared and when the value is 'undefined' (default) the sharing of the memoryMap is undefined.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="memoryMapType">
+		<xs:annotation>
+			<xs:documentation>Map of address space blocks on target target bus interface.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:choice>
+				<xs:element name="memoryMapDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:memoryMapGroup" minOccurs="0"/>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="subspaceMap" type="ipxact:subspaceRefType">
+		<xs:annotation>
+			<xs:documentation>Maps in an address subspace from across a bus bridge.  Its initiatorRef attribute refers by name to the initiator bus interface on the other side of the bridge.  It must match the initiatorRef attribute of a bridge element on the target interface, and that bridge element must be designated as opaque.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="memoryRemap" type="ipxact:memoryRemapType">
+		<xs:annotation>
+			<xs:documentation>Additional memory map elements that are dependent on the component state.</xs:documentation>
+		</xs:annotation>
+		<xs:key name="MRMKey">
+			<xs:selector xpath="ipxact:subspaceMap|ipxact:addressBlock|ipxact:bank"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:unique name="memoryRemapPriorityUnique">
+			<xs:selector xpath="ipxact:modeRef"/>
+			<xs:field xpath="@priority"/>
+		</xs:unique>
+	</xs:element>
+	<xs:complexType name="memoryRemapType">
+		<xs:annotation>
+			<xs:documentation>Map of address space blocks on a target bus interface in a specific remap state.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element ref="ipxact:modeRef" maxOccurs="unbounded"/>
+			<xs:choice>
+				<xs:element name="remapDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:group ref="ipxact:memoryMap" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="memoryRemapDefinitionType">
+		<xs:annotation>
+			<xs:documentation>Map of address space blocks on a target bus interface in a specific remap state.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element ref="ipxact:modeRef" maxOccurs="unbounded"/>
+			<xs:choice>
+				<xs:element name="remapDefinitionRef">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:choice maxOccurs="unbounded">
+					<xs:element name="addressBlock" type="ipxact:addressBlockType">
+						<xs:annotation>
+							<xs:documentation>An address block within the bank.  No address information is supplied.</xs:documentation>
+						</xs:annotation>
+						<xs:key name="remapDefinitionRegisterAndRegisterFileAndABKey">
+							<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+							<xs:field xpath="ipxact:name"/>
+						</xs:key>
+					</xs:element>
+					<xs:element name="bank">
+						<xs:annotation>
+							<xs:documentation>A nested bank of blocks within a bank.  No address information is supplied.</xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+							<xs:complexContent>
+								<xs:extension base="ipxact:bankedDefinitionBankType">
+									<xs:sequence>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+								</xs:extension>
+							</xs:complexContent>
+						</xs:complexType>
+						<xs:key name="memoryRemapDefinition2MMKey">
+							<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+							<xs:field xpath="ipxact:name"/>
+						</xs:key>
+					</xs:element>
+				</xs:choice>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="localMemoryMapType">
+		<xs:annotation>
+			<xs:documentation>Map of address space blocks on the local memory map of a initiator bus interface.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="ipxact:addressBlock"/>
+				<xs:element name="bank" type="ipxact:localAddressBankType">
+					<xs:annotation>
+						<xs:documentation>Represents a bank of memory made up of address blocks or other banks.  It has a bankAlignment attribute indicating whether its blocks are aligned in 'parallel' (occupying adjacent bit fields) or 'serial' (occupying contiguous addresses). Its child blocks do not contain addresses or bit offsets.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="localBankedMMKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:choice>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="subspaceRefType">
+		<xs:annotation>
+			<xs:documentation>Address subspace type.  Its subspaceReference attribute references the subspace from which the dimensions are taken.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>Any parameters that may apply to the subspace reference.</xs:documentation>
+			</xs:annotation>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="baseAddress" type="ipxact:signedLongintExpression">
+				<xs:annotation>
+					<xs:documentation>Base of a subspace map. Expressed as the number of addressable units from the containing memoryMap.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Any parameters that may apply to the subspace reference.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="initiatorRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>For subspaceMap elements, this attribute identifies the initiator that contains the address space to be mapped.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="segmentRef" type="xs:Name">
+			<xs:annotation>
+				<xs:documentation>Refernce to a segment of the addressSpace of the initiatorRef attribute.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="volatile" type="xs:boolean">
+		<xs:annotation>
+			<xs:documentation>Indicates whether the data is volatile.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="fieldAccessPolicyDefinitionRef">
+		<xs:annotation>
+			<xs:documentation>Indicates the accessibility of the data in the field.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:Name">
+					<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="addressBlock" type="ipxact:addressBlockType">
+		<xs:annotation>
+			<xs:documentation>This is a single contiguous block of memory inside a memory map.</xs:documentation>
+		</xs:annotation>
+		<xs:key name="registerAndRegisterFileAndABKey">
+			<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+	</xs:element>
+	<xs:element name="addressSpaces">
+		<xs:annotation>
+			<xs:documentation>If this component is a bus initiator, this lists all the address spaces
+defined by the component.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="addressSpace" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>This defines a logical space, referenced by a bus initiator.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:group ref="ipxact:blockSize"/>
+							<xs:element name="segments" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Address segments withing an addressSpace </xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="segment" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Address segment withing an addressSpace </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:group ref="ipxact:nameGroup"/>
+													<xs:element name="addressOffset" type="ipxact:unsignedLongintExpression">
+														<xs:annotation>
+															<xs:documentation>Address offset of the segment within the containing address space.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="range" type="ipxact:unsignedPositiveLongintExpression">
+														<xs:annotation>
+															<xs:documentation>The address range of asegment.  Expressed as the number of addressable units accessible to the segment. 				</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+												</xs:sequence>
+												<xs:attributeGroup ref="ipxact:id.att"/>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+							<xs:element name="localMemoryMap" type="ipxact:localMemoryMapType" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Provides the local memory map of an address space.  Blocks in this memory map are accessable to initiator interfaces on this component that reference this address space.   They are not accessable to any external initiator interface.</xs:documentation>
+								</xs:annotation>
+								<xs:key name="LMMKey">
+									<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+									<xs:field xpath="ipxact:name"/>
+								</xs:key>
+							</xs:element>
+							<xs:element ref="ipxact:parameters" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Data specific to this address space.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="segmentNameKey">
+						<xs:selector xpath="ipxact:segments/ipxact:segment"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="memoryMapRef" type="ipxact:memoryMapRefType">
+		<xs:annotation>
+			<xs:documentation>References the memory map. The name of the memory map is kept in its memoryMapRef attribute.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="memoryMaps">
+		<xs:annotation>
+			<xs:documentation>Lists all the target memory maps defined by the component.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="memoryMap" type="ipxact:memoryMapType" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>The set of address blocks a bus target contributes to the bus' address space.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="memoryMapRemapModeKey">
+						<xs:selector xpath="ipxact:memoryRemap/ipxact:modeRef"/>
+						<xs:field xpath="."/>
+					</xs:key>
+					<xs:key name="memoryMapItemsKey">
+						<xs:selector xpath="ipxact:subspaceMap|ipxact:addressBlock|ipxact:bank|ipxact:memoryRemap"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="bank" type="ipxact:addressBankType">
+		<xs:annotation>
+			<xs:documentation>Represents a bank of memory made up of address blocks or other banks.  It has a bankAlignment attribute indicating whether its blocks are aligned in 'parallel' (occupying adjacent bit fields) or 'serial' (occupying contiguous addresses). Its child blocks do not contain addresses or bit offsets.</xs:documentation>
+		</xs:annotation>
+		<xs:key name="bankedMMKey">
+			<xs:selector xpath="ipxact:subspaceMap|ipxact:addressBlock|ipxact:bank"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+	</xs:element>
+	<xs:element name="baseAddress" type="ipxact:unsignedLongintExpression">
+		<xs:annotation>
+			<xs:documentation>Base of an address block, bank or address space. Expressed as the number of addressable units from the containing memoryMap or localMemoryMap.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="addressUnitBits" type="ipxact:unsignedPositiveLongintExpression">
+		<xs:annotation>
+			<xs:documentation>The number of data bits in an addressable unit. The default is byte addressable (8 bits).</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:group name="addressBlockExtensions">
+		<xs:annotation>
+			<xs:documentation>This is a group of optional elements commonly added to various types of address blocks in a memory map.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:memoryBlockData"/>
+			<xs:group ref="ipxact:registerData" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="addressSpecifier">
+		<xs:annotation>
+			<xs:documentation>This group of elements describes an absolute or relative address of an address block in a memory map.
+
+Note that this is a group, not an element.  It does not appear in the XML, but its contents may.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:baseAddress"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="bankBase">
+		<xs:annotation>
+			<xs:documentation>This group of elements is common to top level banks and banked banks.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element name="addressBlock" type="ipxact:bankedBlockType">
+					<xs:annotation>
+						<xs:documentation>An address block within the bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="bankedRegisterAndRegisterFileAndABKey">
+						<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="bank">
+					<xs:annotation>
+						<xs:documentation>A nested bank of blocks within a bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="ipxact:bankedBankType">
+								<xs:sequence>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+					<xs:key name="banked2MMKey">
+						<xs:selector xpath="ipxact:subspaceMap|ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="subspaceMap" type="ipxact:bankedSubspaceType">
+					<xs:annotation>
+						<xs:documentation>A subspace map within the bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:group ref="ipxact:memoryBlockData"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="bankDefinitionBase">
+		<xs:annotation>
+			<xs:documentation>This group of elements is common to top level bank definitions and banked bank definitions.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element name="addressBlock" type="ipxact:bankedBlockType">
+					<xs:annotation>
+						<xs:documentation>An address block within the bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="bankedDefinitionRegisterAndRegisterFileAndABKey">
+						<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="bank">
+					<xs:annotation>
+						<xs:documentation>A nested bank of blocks within a bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="ipxact:bankedDefinitionBankType">
+								<xs:sequence>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+					<xs:key name="bankedDefinition2MMKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:choice>
+			<xs:group ref="ipxact:memoryBlockData"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="localBankBase">
+		<xs:annotation>
+			<xs:documentation>This group of elements is common to top level banks and banked banks.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element name="addressBlock" type="ipxact:bankedBlockType">
+					<xs:annotation>
+						<xs:documentation>An address block within the bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="localBankedRegisterAndRegisterFileAndABKey">
+						<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="bank" type="ipxact:localBankedBankType">
+					<xs:annotation>
+						<xs:documentation>A nested bank of blocks within a bank.  No address information is supplied.</xs:documentation>
+					</xs:annotation>
+					<xs:key name="localBankedBankMMKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:choice>
+			<xs:group ref="ipxact:memoryBlockData"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="blockSize">
+		<xs:annotation>
+			<xs:documentation>This group of elements describes the number of addressable units and the width of a row of an address block in a memory map.
+
+Note that this is a group, not an element.  It does not appear in the XML, but its contents may.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="range" type="ipxact:unsignedPositiveLongintExpression">
+				<xs:annotation>
+					<xs:documentation>The address range of an address block.  Expressed as the number of addressable units accessible to the block. The range and the width are related by the following formulas:
+					number_of_bits_in_block = ipxact:addressUnitBits * ipxact:range
+					number_of_rows_in_block = number_of_bits_in_block / ipxact:width
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="width" type="ipxact:unsignedPositiveIntExpression">
+				<xs:annotation>
+					<xs:documentation>The bit width of a row in the address block. The range and the width are related by the following formulas:
+					number_of_bits_in_block = ipxact:addressUnitBits * ipxact:range
+					number_of_rows_in_block = number_of_bits_in_block / ipxact:width
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="memoryBlockData">
+		<xs:annotation>
+			<xs:documentation>This group of optional elements can be used to provide additional descriptions to an address block or bank.
+
+Note that this is a group, not an element.  It does not appear in the XML, but its contents may.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="usage" type="ipxact:usageType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indicates the usage of this block.  Possible values are 'memory', 'register' and 'reserved'.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:volatile" minOccurs="0"/>
+			<xs:element ref="ipxact:accessPolicies" minOccurs="0"/>
+			<xs:element ref="ipxact:parameters" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Any additional parameters needed to describe this address block to the generators.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:element name="dim">
+		<xs:annotation>
+			<xs:documentation>Dimensions a register array, the semantics for dim elements are the same as the C language standard for the  layout of memory in multidimensional arrays.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:unsignedPositiveLongintExpression">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+					<xs:attribute name="indexVar" type="xs:Name" use="optional">
+						<xs:annotation>
+							<xs:documentation>Name for the index to allow referring to it in names and prosa.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="stride">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:unsignedPositiveLongintExpression">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="bitStride">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:unsignedPositiveLongintExpression">
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:group name="registerData">
+		<xs:annotation>
+			<xs:documentation>This group of optional elements describes the memory mapped registers of an address block</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="register">
+				<xs:annotation>
+					<xs:documentation>A single register</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="ipxact:nameGroup"/>
+						<xs:element name="accessHandles" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence minOccurs="1" maxOccurs="unbounded">
+									<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element ref="ipxact:array" minOccurs="0"/>
+						<xs:element name="addressOffset" type="ipxact:unsignedLongintExpression">
+							<xs:annotation>
+								<xs:documentation>Offset from the address block's baseAddress or the containing register file's addressOffset, expressed as the number of addressUnitBits from the containing memoryMap or localMemoryMap.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="registerDefinitionRef">
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="xs:Name">
+											<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+							<xs:group ref="ipxact:registerDefinitionGroup"/>
+						</xs:choice>
+						<xs:element ref="ipxact:alternateRegisters" minOccurs="0"/>
+						<xs:element ref="ipxact:parameters" minOccurs="0"/>
+						<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+					</xs:sequence>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:complexType>
+				<xs:key name="registerFieldKey">
+					<xs:selector xpath="ipxact:field"/>
+					<xs:field xpath="ipxact:name"/>
+				</xs:key>
+				<!-- IFX PSS 61 -->
+				<xs:unique name="registerFileDimIndexVarUnique">
+					<xs:selector xpath="./ipxact:array/ipxact:dim"/>
+					<xs:field xpath="@indexVar"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element ref="ipxact:registerFile">
+				<xs:annotation>
+					<xs:documentation>A structure of registers and register files</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:element name="alternateRegisters">
+		<xs:annotation>
+			<xs:documentation>Alternate definitions for the current register</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="alternateRegister" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Alternate definition for the current register</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:element name="accessHandles" minOccurs="0">
+								<xs:complexType>
+									<xs:sequence minOccurs="1" maxOccurs="unbounded">
+										<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="ipxact:modeRef" maxOccurs="unbounded"/>
+							<xs:group ref="ipxact:alternateRegisterDefinitionGroup"/>
+							<xs:element ref="ipxact:parameters" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:unique name="alternateRegisterPriorityUnique">
+						<xs:selector xpath="ipxact:modeRef"/>
+						<xs:field xpath="@priority"/>
+					</xs:unique>
+					<xs:key name="alternateRegisterFieldKey">
+						<xs:selector xpath="ipxact:field"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:key name="alternateRegisterModeRefKey">
+			<xs:selector xpath="ipxact:alternateRegister/ipxact:modeRef"/>
+			<xs:field xpath="."/>
+		</xs:key>
+		<xs:unique name="alternateRegisterNameUnique">
+			<xs:selector xpath="ipxact:alternateRegister"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="enumeratedValues">
+		<xs:annotation>
+			<xs:documentation>Enumerates specific values that can be assigned to the bit field.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:choice>
+				<xs:element name="enumerationDefinitionRef">
+					<xs:annotation>
+						<xs:documentation>References an enumeration to be found in a local or external library.  The four attributes define the VLNV of the referenced element.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="enumeratedValue" type="ipxact:enumeratedValueType" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Enumerates specific values that can be assigned to the bit field. The name of this enumerated value. This may be used as a token in generating code.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:complexType>
+		<xs:key name="enumKey">
+			<xs:selector xpath="ipxact:enumeratedValue"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+	</xs:element>
+	<xs:complexType name="enumeratedValueType">
+		<xs:annotation>
+			<xs:documentation>Enumerates specific values that can be assigned to the bit field. The name of this enumerated value. This may be used as a token in generating code.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="value" type="ipxact:unsignedBitVectorExpression">
+				<xs:annotation>
+					<xs:documentation>Enumerated bit field value.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="usage" default="read-write">
+			<xs:annotation>
+				<xs:documentation>Usage for the enumeration. 'read' for a software read access. 'write' for a software write access. 'read-write' for a software read or write access.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="read"/>
+					<xs:enumeration value="write"/>
+					<xs:enumeration value="read-write"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:simpleType name="modifiedWriteValueType">
+		<xs:restriction base="xs:Name">
+			<xs:enumeration value="oneToClear"/>
+			<xs:enumeration value="oneToSet"/>
+			<xs:enumeration value="oneToToggle"/>
+			<xs:enumeration value="zeroToClear"/>
+			<xs:enumeration value="zeroToSet"/>
+			<xs:enumeration value="zeroToToggle"/>
+			<xs:enumeration value="clear"/>
+			<xs:enumeration value="set"/>
+			<xs:enumeration value="modify"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="readActionType">
+		<xs:restriction base="xs:Name">
+			<xs:enumeration value="clear"/>
+			<xs:enumeration value="set"/>
+			<xs:enumeration value="modify"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="accessRestrictionType">
+		<xs:sequence>
+			<xs:element ref="ipxact:modeRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="readAccessMask" type="ipxact:unsignedBitVectorExpression" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mask to be anded with the readable bits in this field to determine the readabe bits in this access mode. If not present, the value defaults to "all ones" meaning that read access is not blocked.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="writeAccessMask" type="ipxact:unsignedBitVectorExpression" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mask to be anded with the writable bits in this field to determine the writeable bits in this access mode.  If not present, the value defaults to "all ones" meaning that write access is not blocked.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="accessRestrictionsType">
+		<xs:sequence>
+			<xs:element name="accessRestriction" type="ipxact:accessRestrictionType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Access mode.</xs:documentation>
+				</xs:annotation>
+				<xs:unique name="accessRestrictionPriorityUnique">
+					<xs:selector xpath="ipxact:modeRef"/>
+					<xs:field xpath="@priority"/>
+				</xs:unique>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="fieldAccessPropertiesType">
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="accessPropertiesType">
+		<xs:sequence/>
+		<xs:attribute name="accessEntryTypeRef" type="xs:Name">
+			<xs:annotation>
+				<xs:documentation>Reference to a user defined accessEntryType. Assumed to be DEFAULT if not present.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:group name="fieldData">
+		<xs:annotation>
+			<xs:documentation>Additional field data</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="fieldAccessPolicies" minOccurs="0">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="ipxact:fieldAccessPropertiesType">
+							<xs:sequence>
+								<xs:element name="fieldAccessPolicy" maxOccurs="unbounded">
+									<xs:complexType>
+										<xs:sequence>
+											<xs:element ref="ipxact:modeRef" minOccurs="0" maxOccurs="unbounded"/>
+											<xs:choice>
+												<xs:element ref="ipxact:fieldAccessPolicyDefinitionRef" minOccurs="0"/>
+												<xs:sequence>
+													<xs:element ref="ipxact:access" minOccurs="0"/>
+													<xs:element ref="ipxact:modifiedWriteValue" minOccurs="0"/>
+													<xs:element ref="ipxact:writeValueConstraint" minOccurs="0"/>
+													<xs:element ref="ipxact:readAction" minOccurs="0"/>
+													<xs:element ref="ipxact:readResponse" minOccurs="0"/>
+												</xs:sequence>
+											</xs:choice>
+											<xs:element name="broadcasts" minOccurs="0">
+												<xs:complexType>
+													<xs:sequence>
+														<xs:element name="broadcastTo" maxOccurs="unbounded">
+															<xs:complexType>
+																<xs:group ref="ipxact:fieldReferenceGroup"/>
+																<xs:attributeGroup ref="ipxact:id.att"/>
+															</xs:complexType>
+														</xs:element>
+													</xs:sequence>
+												</xs:complexType>
+											</xs:element>
+											<xs:element ref="ipxact:accessRestrictions" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation>Access restrictions</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="testable" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation>Can the field be tested with an automated register test routine. The presumed value is true if not specified.</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+													<xs:simpleContent>
+														<xs:extension base="xs:boolean">
+															<xs:attribute name="testConstraint" default="unconstrained">
+																<xs:annotation>
+																	<xs:documentation>Constraint for an automated register test routine. 'unconstrained' (default) means may read and write all legal values. 'restore' means may read and write legal values but the value must be restored to the initially read value before accessing another register. 'writeAsRead' has limitations on testability where only the value read before a write may be written to the field. 'readOnly' has limitations on testability where values may only be read from the field.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:enumeration value="unconstrained"/>
+																		<xs:enumeration value="restore"/>
+																		<xs:enumeration value="writeAsRead"/>
+																		<xs:enumeration value="readOnly"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:attribute>
+														</xs:extension>
+													</xs:simpleContent>
+												</xs:complexType>
+											</xs:element>
+											<xs:element name="reserved" type="ipxact:unsignedBitExpression" default="0" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation>Indicates that the field should be documented as reserved. The presumed value is '0' if not present.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+										</xs:sequence>
+										<xs:attributeGroup ref="ipxact:id.att"/>
+									</xs:complexType>
+									<xs:unique name="accessFieldpolicyPriorityUnique">
+										<xs:selector xpath="ipxact:modeRef"/>
+										<xs:field xpath="@priority"/>
+									</xs:unique>
+								</xs:element>
+							</xs:sequence>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:enumeratedValues" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="writeValueConstraintType">
+		<xs:annotation>
+			<xs:documentation>A constraint on the values that can be written to this field. Absence of this element implies that any value that fits can be written to it.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="writeAsRead" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>writeAsRead indicates that only a value immediately read before a write is a legal value to be written.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="useEnumeratedValues" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>useEnumeratedValues indicates that only write enumeration value shall be legal values to be written.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence>
+				<xs:element name="minimum" type="ipxact:unsignedBitVectorExpression">
+					<xs:annotation>
+						<xs:documentation>The minimum legal value that may be written to a field</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="maximum" type="ipxact:unsignedBitVectorExpression">
+					<xs:annotation>
+						<xs:documentation>The maximum legal value that may be written to a field</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:choice>
+	</xs:complexType>
+	<xs:element name="registerFile">
+		<xs:annotation>
+			<xs:documentation>A structure of registers and register files</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroup"/>
+				<xs:element name="accessHandles" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence minOccurs="1" maxOccurs="unbounded">
+							<xs:element name="accessHandle" type="ipxact:simpleAccessHandle"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:array" minOccurs="0"/>
+				<xs:element name="addressOffset" type="ipxact:unsignedLongintExpression">
+					<xs:annotation>
+						<xs:documentation>Offset from the address block's baseAddress or the containing register file's addressOffset, expressed as the number of addressUnitBits from the containing memoryMap or localMemoryMap.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:choice>
+					<xs:element name="registerFileDefinitionRef">
+						<xs:complexType>
+							<xs:simpleContent>
+								<xs:extension base="xs:Name">
+									<xs:attribute name="typeDefinitions" type="xs:Name" use="required"/>
+								</xs:extension>
+							</xs:simpleContent>
+						</xs:complexType>
+					</xs:element>
+					<xs:group ref="ipxact:registerFileDefinitionGroup"/>
+				</xs:choice>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:key name="registerAndRegisterFile1Key">
+			<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:unique name="registerDimIndexVarUnique">
+			<xs:selector xpath="./ipxact:array/ipxact:dim"/>
+			<xs:field xpath="@indexVar"/>
+		</xs:unique>
+	</xs:element>
+	<xs:group name="fieldDefinitionGroup">
+		<xs:annotation>
+			<xs:documentation>Field definition specific information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="typeIdentifier" type="xs:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identifier name used to indicate that multiple field elements contain the exact same information for the elements in the fieldDefinitionGroup.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:sequence>
+					<xs:element name="bitWidth" type="ipxact:unsignedPositiveIntExpression">
+						<xs:annotation>
+							<xs:documentation>Width of the field in bits.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="volatile" type="xs:boolean" default="false" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Indicates whether the data is volatile. The presumed value is 'false' if not present.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="resets" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element ref="ipxact:reset" maxOccurs="unbounded">
+									<xs:annotation>
+										<xs:documentation>BitField reset value</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+				<xs:element name="aliasOf">
+					<xs:complexType>
+						<xs:group ref="ipxact:fieldReferenceGroup"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+			<xs:group ref="ipxact:fieldData"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="registerFileDefinitionGroup">
+		<xs:annotation>
+			<xs:documentation>Register file defnition specific information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="typeIdentifier" type="xs:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identifier name used to indicate that multiple registerFile elements contain the exact same information except for the elements in the registerFileInstanceGroup.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="range" type="ipxact:unsignedPositiveLongintExpression">
+				<xs:annotation>
+					<xs:documentation>The range of a register file.  Expressed as the number of addressable units accessible to the block. Specified in units of addressUnitBits.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:accessPolicies" minOccurs="0"/>
+			<xs:group ref="ipxact:registerData" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="addressBlockDefinitionGroup">
+		<xs:annotation>
+			<xs:documentation>Address block definition specific information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="typeIdentifier" type="xs:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identifier name used to indicate that multiple addressBlock elements contain the exact same information except for the elements in the addressBlockInstanceGroup.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="ipxact:blockSize"/>
+			<xs:group ref="ipxact:memoryBlockData"/>
+			<xs:group ref="ipxact:registerData" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="registerDefinitionGroup">
+		<xs:annotation>
+			<xs:documentation>Register definition specific information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="typeIdentifier" type="xs:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identifier name used to indicate that multiple register elements contain the exact same information for the elements in the registerDefinitionGroup.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="size" type="ipxact:unsignedPositiveIntExpression">
+				<xs:annotation>
+					<xs:documentation>Width of the register in bits.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:volatile" minOccurs="0"/>
+			<xs:element ref="ipxact:accessPolicies" minOccurs="0"/>
+			<xs:sequence minOccurs="1" maxOccurs="unbounded">
+				<xs:element name="field" type="ipxact:fieldType">
+					<xs:annotation>
+						<xs:documentation>Describes individual bit fields within the register.</xs:documentation>
+					</xs:annotation>
+					<xs:unique name="fieldResetTypeRefKey">
+						<xs:selector xpath="ipxact:resets/ipxact:reset"/>
+						<xs:field xpath="@resetTypeRef"/>
+					</xs:unique>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="alternateRegisterDefinitionGroup">
+		<xs:annotation>
+			<xs:documentation>Alternate register definition specific information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="typeIdentifier" type="xs:Name" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identifier name used to indicate that multiple register elements contain the exact same information for the elements in the alternateRegisterDefinitionGroup.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:volatile" minOccurs="0"/>
+			<xs:element ref="ipxact:accessPolicies" minOccurs="0"/>
+			<xs:sequence minOccurs="1" maxOccurs="unbounded">
+				<xs:element name="field" type="ipxact:fieldType">
+					<xs:annotation>
+						<xs:documentation>Describes individual bit fields within the register.</xs:documentation>
+					</xs:annotation>
+					<xs:unique name="alternateFieldResetTypeKey">
+						<xs:selector xpath="ipxact:resets/ipxact:reset"/>
+						<xs:field xpath="@resetTypeRef"/>
+					</xs:unique>
+					<xs:unique name="alternateFieldDimIndexVarUnique">
+						<xs:selector xpath="./ipxact:array/ipxact:dim"/>
+						<xs:field xpath="@indexVar"/>
+					</xs:unique>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:group>
+	<xs:element name="reset">
+		<xs:annotation>
+			<xs:documentation>Register value at reset.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="value" type="ipxact:unsignedBitVectorExpression">
+					<xs:annotation>
+						<xs:documentation>The value itself.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="mask" type="ipxact:unsignedBitVectorExpression" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Mask to be anded with the value before comparing to the reset value.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="resetTypeRef" type="xs:Name">
+				<xs:annotation>
+					<xs:documentation>Reference to a user defined resetType. Assumed to be HARD if not present.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="externalTypeDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroup"/>
+				<xs:element name="typeDefinitionsRef" type="ipxact:configurableLibraryRefType">
+					<xs:annotation>
+						<xs:documentation>References a type definitions to be found in an external file.  The four attributes define the VLNV of the referenced document.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:viewLinks" minOccurs="0"/>
+				<xs:element ref="ipxact:modeLinks" minOccurs="0"/>
+				<xs:element ref="ipxact:resetTypeLinks" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="enumerationDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="enumerationDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:element name="width" type="ipxact:unsignedPositiveIntExpression">
+								<xs:annotation>
+									<xs:documentation>Definition width used to resolve the value.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="enumeratedValue" type="ipxact:enumeratedValueType" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Enumerates specific values that can be assigned to the bit field. The name of this enumerated value. This may be used as a token in generating code.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="enumerationDefinitionEnumeratedValueKey">
+						<xs:selector xpath="ipxact:enumeratedValue"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fieldAccessPolicyDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="fieldAccessPolicyDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:element ref="ipxact:access" minOccurs="0"/>
+							<xs:element ref="ipxact:modifiedWriteValue" minOccurs="0"/>
+							<xs:element ref="ipxact:writeValueConstraint" minOccurs="0"/>
+							<xs:element ref="ipxact:readAction" minOccurs="0"/>
+							<xs:element ref="ipxact:readResponse" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fieldDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="fieldDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:element name="typeIdentifier" type="xs:Name" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Identifier name used to indicate that multiple field elements contain the exact same information for the elements in the fieldDefinitionGroup.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="bitWidth" type="ipxact:unsignedPositiveIntExpression">
+								<xs:annotation>
+									<xs:documentation>Width of the field in bits.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="volatile" type="xs:boolean" default="false" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Indicates whether the data is volatile. The presumed value is 'false' if not present.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="resets" minOccurs="0">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="ipxact:reset" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>BitField reset value</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:group ref="ipxact:fieldData"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:unique name="fieldDefinitionResetTypeRefKey">
+						<xs:selector xpath="ipxact:resets/ipxact:reset"/>
+						<xs:field xpath="@resetTypeRef"/>
+					</xs:unique>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="registerDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="registerDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:group ref="ipxact:registerDefinitionGroup"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="registerDefinitionFieldKey">
+						<xs:selector xpath="ipxact:field"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="registerFileDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="registerFileDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:group ref="ipxact:registerFileDefinitionGroup"/>
+							<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="registerFileDefinitionRegisterAndRegisterFileKey">
+						<xs:selector xpath="ipxact:register|ipxact:registerFile"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="addressBlockDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="addressBlockDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:group ref="ipxact:addressBlockDefinitionGroup"/>
+							<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="addressBlockDefinitionRegisterAndRegisterFileAndAlternateRegisterKey">
+						<xs:selector xpath="ipxact:register|ipxact:registerFile|ipxact:register/ipxact:alternateRegisters/ipxact:alternateRegister"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="bankDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="bankDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:group ref="ipxact:bankDefinitionBase"/>
+							<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="bankDefinitionAddressBlockAndBankKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="memoryMapDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="memoryMapDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:group ref="ipxact:memoryMapDefinitionTypeGroup" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="memoryMapDefinitionRemapModeKey">
+						<xs:selector xpath="ipxact:memoryRemap/ipxact:modeRef"/>
+						<xs:field xpath="."/>
+					</xs:key>
+					<xs:key name="memoryMapDefinitionItemsKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank|ipxact:memoryRemap"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="memoryRemapDefinitions">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="memoryRemapDefinition" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:group ref="ipxact:nameGroup"/>
+							<xs:choice maxOccurs="unbounded">
+								<xs:element ref="ipxact:addressBlock"/>
+								<xs:element name="bank" type="ipxact:addressBankDefinitionType">
+									<xs:annotation>
+										<xs:documentation>An addressable bank of blocks within a bank definition.</xs:documentation>
+									</xs:annotation>
+									<xs:key name="remapDefinition2MMKey">
+										<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+										<xs:field xpath="ipxact:name"/>
+									</xs:key>
+								</xs:element>
+							</xs:choice>
+							<xs:element ref="ipxact:addressUnitBits" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:key name="memoryRemapDefinitionItemsKey">
+						<xs:selector xpath="ipxact:addressBlock|ipxact:bank"/>
+						<xs:field xpath="ipxact:name"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="modeRef">
+		<xs:annotation>
+			<xs:documentation>A reference to a mode.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:Name">
+					<xs:attribute name="priority" type="xs:nonNegativeInteger" use="required"/>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="array">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:dim" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Dimensions a memory-map element array, the semantics for dim elements are the same as the C language standard for the  layout of memory in multidimensional arrays.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:stride" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="access" type="ipxact:accessType"/>
+	<xs:element name="modifiedWriteValue">
+		<xs:annotation>
+			<xs:documentation>If present this element describes the modification of field data caused by a write operation. 'oneToClear' means that in a bitwise fashion each write data bit of a one will clear the corresponding bit in the field. 'oneToSet' means that in a bitwise fashion each write data bit of a one will set the corresponding bit in the field.  'oneToToggle' means that in a bitwise fashion each write data bit of a one will toggle the corresponding bit in the field. 'zeroToClear' means that in a bitwise fashion each write data bit of a zero will clear the corresponding bit in the field. 'zeroToSet' means that in a bitwise fashion each write data bit of a zero will set the corresponding bit in the field. 'zeroToToggle' means that in a bitwise fashion each write data bit of a zero will toggle the corresponding bit in the field. 'clear' means any write to this field clears the field. 'set' means any write to the field sets the field. 'modify' means any write to this field may modify that data. If this element is not present the write operation data is written.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:modifiedWriteValueType">
+					<xs:attribute name="modify" type="xs:Name"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="writeValueConstraint" type="ipxact:writeValueConstraintType">
+		<xs:annotation>
+			<xs:documentation>The legal values that may be written to a field. If not specified the legal values are not specified.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="readAction">
+		<xs:annotation>
+			<xs:documentation>A list of possible actions for a read to set the field after the read. 'clear' means that after a read the field is cleared. 'set' means that after a read the field is set. 'modify' means after a read the field is modified. If not present the field value is not modified after a read.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:readActionType">
+					<xs:attribute name="modify" type="xs:Name"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="readResponse" type="ipxact:unsignedBitVectorExpression"/>
+	<xs:element name="accessRestrictions" type="ipxact:accessRestrictionsType">
+		<xs:annotation>
+			<xs:documentation>Access modes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="accessPolicies">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="accessPolicy" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="ipxact:modeRef" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="access" type="ipxact:accessType" minOccurs="0"/>
+							<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+					<xs:unique name="accessPolicyPriorityUnique">
+						<xs:selector xpath="ipxact:modeRef"/>
+						<xs:field xpath="@priority"/>
+					</xs:unique>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/model.xsd
+++ b/ieee-1685-2022/model.xsd
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="file.xsd"/>
+	<xs:include schemaLocation="port.xsd"/>
+	<xs:simpleType name="envIdentifierType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-zA-Z0-9_+\*\.]*:[a-zA-Z0-9_+\*\.]*:[a-zA-Z0-9_+\*\.]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="designInstantiationType">
+		<xs:annotation>
+			<xs:documentation>Design instantiation type.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupNMTOKEN"/>
+			<xs:element name="designRef" type="ipxact:configurableLibraryRefType">
+				<xs:annotation>
+					<xs:documentation>References an IP-XACT design document (by VLNV) that provides a design for the component.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="designConfigurationInstantiationType">
+		<xs:annotation>
+			<xs:documentation>Design configuration instantiation type.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupNMTOKEN"/>
+			<xs:element name="language" type="ipxact:languageType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation> The hardware description language used such as "verilog" or "vhdl". If the attribute "strict" is "true", this value must match the language being generated for the design.  </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="designConfigurationRef" type="ipxact:configurableLibraryRefType">
+				<xs:annotation>
+					<xs:documentation>References an IP-XACT design configuration document (by VLNV) that provides a configuration for the component's design.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="componentInstantiationType">
+		<xs:annotation>
+			<xs:documentation>Component instantiation type</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupNMTOKEN"/>
+			<xs:element name="isVirtual" type="xs:boolean" default="false" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>When true, indicates that this component should not be netlisted.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="language" type="ipxact:languageType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation> The hardware description language used such as "verilog" or "vhdl". If the attribute "strict" is "true", this value must match the language being generated for the design.  </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="libraryName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A string specifying the library name in which the model should be compiled. If the libraryName element is not present then its value defaults to “work”.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="packageName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A string describing the VHDL package containing the interface of the model. If the packageName element is not present then its value defaults to the component VLNV name concatenated with postfix “_cmp_pkg” which stands for component package.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="moduleName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A string describing the Verilog, SystemVerilog, or SystemC module name or the VHDL entity name. If the moduleName is not present then its value defaults to the component VLNV name</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="architectureName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A string describing the VHDL architecture name. If the architectureName element is not present then its value defaults to “rtl”.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="configurationName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A string describing the Verilog, SystemVerilog, or VHDL configuration name. If the configurationName element is not present then its value defaults to the design configuration VLNV name of the design configuration associated with the active hierarchical view or, if there is no active hierarchical view, to the component VLNV name concatenated with postfix “_rtl_cfg”.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="moduleParameters" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Model parameter name value pairs container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="moduleParameter" type="ipxact:moduleParameterType" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>A module parameter name value pair. The name is given in an attribute. The value is the element value. The dataType (applicable to high level modeling) is given in the dataType attribute. For hardware based models, the name should be identical to the RTL (VHDL generic or Verilog parameter). The usageType attribute indicates how the model parameter is to be used.
+										</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+				<xs:unique name="moduleParameterName">
+					<xs:selector xpath="ipxact:moduleParameter"/>
+					<xs:field xpath="ipxact:name"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="defaultFileBuilder" type="ipxact:fileBuilderType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Default command and flags used to build derived files from the sourceName files in the referenced file sets.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:fileSetRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ipxact:constraintSetRef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="clearboxElementRefs" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation> Container for clear box element references.  </xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="clearboxElementRef" type="ipxact:clearboxElementRefType" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation> Reference to a clear box element which is visible within this view.  </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:group name="instantiationsGroup">
+		<xs:choice>
+			<xs:element name="componentInstantiation" type="ipxact:componentInstantiationType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Component Instantiation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="designInstantiation" type="ipxact:designInstantiationType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Design Instantiation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="designConfigurationInstantiation" type="ipxact:designConfigurationInstantiationType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Design Configuration Instantiation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:complexType name="modelType">
+		<xs:annotation>
+			<xs:documentation>Model information.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="views" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Views container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="view" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Single view of a component</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="ipxact:nameGroupNMTOKEN"/>
+									<xs:element name="envIdentifier" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation> Defines the hardware environment in which this view applies. The format of the string is language:tool:vendor_extension, with each piece being optional. The language must be one of the types from ipxact:fileType. The tool values are defined by the Accellera Systems Initiative, and include generic values "*Simulation" and "*Synthesis" to imply any tool of the indicated type. Having more than one envIdentifier indicates that the view applies to multiple environments.  </xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="ipxact:envIdentifierType">
+													<xs:attributeGroup ref="ipxact:id.att"/>
+												</xs:extension>
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="componentInstantiationRef" type="xs:NMTOKEN" minOccurs="0"/>
+									<xs:element name="designInstantiationRef" type="xs:NMTOKEN" minOccurs="0"/>
+									<xs:element name="designConfigurationInstantiationRef" type="xs:NMTOKEN" minOccurs="0"/>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="instantiations" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Instantiations container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:choice>
+						<xs:group ref="ipxact:instantiationsGroup" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Component, design, designConfiguration instantiation view of a component</xs:documentation>
+							</xs:annotation>
+						</xs:group>
+					</xs:choice>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ports" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Port container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:port" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="abstractorModelType">
+		<xs:annotation>
+			<xs:documentation>Model information for an abstractor.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="views" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Views container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="view" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Single view of an abstracto</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="ipxact:nameGroupNMTOKEN"/>
+									<xs:element name="envIdentifier" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation> Defines the hardware environment in which this view applies. The format of the string is language:tool:vendor_extension, with each piece being optional. The language must be one of the types from ipxact:fileType. The tool values are defined by the Accellera Systems Initiative, and include generic values "*Simulation" and "*Synthesis" to imply any tool of the indicated type. Having more than one envIdentifier indicates that the view applies to multiple environments.  </xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="ipxact:envIdentifierType">
+													<xs:attributeGroup ref="ipxact:id.att"/>
+												</xs:extension>
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="componentInstantiationRef" type="xs:NMTOKEN" minOccurs="0"/>
+									<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="instantiations" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Instantiations container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="componentInstantiation" type="ipxact:componentInstantiationType" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Component Instantiation</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ports" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Port container</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="port" type="ipxact:abstractorPortType" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="model" type="ipxact:modelType">
+		<xs:annotation>
+			<xs:documentation>Model information.</xs:documentation>
+		</xs:annotation>
+		<xs:key name="instantiationsKey">
+			<xs:selector xpath="./ipxact:instantiations/ipxact:componentInstantiation | ./ipxact:instantiations/ipxact:designInstantiation | ./ipxact:instantiations/ipxact:designConfigurationInstantiation"/>
+			<xs:field xpath="./ipxact:name"/>
+		</xs:key>
+		<xs:key name="componentInstantiationsKey">
+			<xs:selector xpath="./ipxact:instantiations/ipxact:componentInstantiation"/>
+			<xs:field xpath="./ipxact:name"/>
+		</xs:key>
+		<xs:key name="designInstantiationsKey">
+			<xs:selector xpath="./ipxact:instantiations/ipxact:designInstantiation"/>
+			<xs:field xpath="./ipxact:name"/>
+		</xs:key>
+		<xs:key name="designConfigurationInstantiationsKey">
+			<xs:selector xpath="./ipxact:instantiations/ipxact:designConfigurationInstantiation"/>
+			<xs:field xpath="./ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="componentInstantiationsRef" refer="ipxact:componentInstantiationsKey">
+			<xs:selector xpath="./ipxact:views/ipxact:view/ipxact:componentInstantiationRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="designInstantiationsRef" refer="ipxact:designInstantiationsKey">
+			<xs:selector xpath="./ipxact:views/ipxact:view/ipxact:designInstantiationRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:keyref name="designConfigurationInstantiationsRef" refer="ipxact:designConfigurationInstantiationsKey">
+			<xs:selector xpath="./ipxact:views/ipxact:view/ipxact:designConfigurationInstantiationRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+	</xs:element>
+	<xs:complexType name="clearboxElementRefType">
+		<xs:annotation>
+			<xs:documentation> Reference to a clearboxElement within a view. The 'name' attribute must refer to a clearboxElement defined within this component.  </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="location" type="ipxact:slicesType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The contents of each location element can be used to specified one location (HDL Path) through the referenced clearBoxElement is accessible.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to a clearboxElement defined within this component.  </xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="languageType">
+		<xs:simpleContent>
+			<xs:extension base="xs:token">
+				<xs:attribute name="strict" type="xs:boolean" default="false">
+					<xs:annotation>
+						<xs:documentation>A value of 'true' indicates that this value must match the language being generated for the design.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/port.xsd
+++ b/ieee-1685-2022/port.xsd
@@ -1,0 +1,1161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="constraints.xsd"/>
+	<xs:include schemaLocation="file.xsd"/>
+	<xs:include schemaLocation="subInstances.xsd"/>
+	<xs:include schemaLocation="busInterface.xsd"/>
+	<xs:simpleType name="componentPortDirectionType">
+		<xs:annotation>
+			<xs:documentation>The direction of a component port.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:enumeration value="in"/>
+			<xs:enumeration value="out"/>
+			<xs:enumeration value="inout"/>
+			<xs:enumeration value="phantom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="portType">
+		<xs:annotation>
+			<xs:documentation>A port description, giving a name and an access type for high level ports. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupPort"/>
+			<xs:choice>
+				<xs:annotation>
+					<xs:documentation>Port style</xs:documentation>
+				</xs:annotation>
+				<xs:element name="wire" type="ipxact:portWireType">
+					<xs:annotation>
+						<xs:documentation>Defines a port whose type resolves to simple bits.</xs:documentation>
+					</xs:annotation>
+					<xs:unique name="WireVectorId">
+						<xs:selector xpath="ipxact:vectors/ipxact:vector"/>
+						<xs:field xpath="@vectorId"/>
+					</xs:unique>
+				</xs:element>
+				<xs:element name="transactional" type="ipxact:portTransactionalType">
+					<xs:annotation>
+						<xs:documentation>Defines a port that implements or uses a service that can be implemented with functions or methods.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="structured" type="ipxact:portStructuredType">
+					<xs:annotation>
+						<xs:documentation>Represents a port that has subport structure.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element ref="ipxact:fieldMaps" minOccurs="0"/>
+			<xs:element ref="ipxact:arrays" minOccurs="0"/>
+			<xs:element name="access" type="ipxact:portAccessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Port access characteristics.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="abstractorPortType">
+		<xs:annotation>
+			<xs:documentation>A port description, giving a name and an access type for high level ports. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupPort"/>
+			<xs:choice>
+				<xs:annotation>
+					<xs:documentation>Port style</xs:documentation>
+				</xs:annotation>
+				<xs:element name="wire" type="ipxact:abstractorPortWireType">
+					<xs:annotation>
+						<xs:documentation>Defines a port whose type resolves to simple bits.</xs:documentation>
+					</xs:annotation>
+					<xs:unique name="AbstractWireVectorIdUnique">
+						<xs:selector xpath="ipxact:vectors/ipxact:vector"/>
+						<xs:field xpath="@vectorId"/>
+					</xs:unique>
+				</xs:element>
+				<xs:element name="transactional" type="ipxact:abstractorPortTransactionalType">
+					<xs:annotation>
+						<xs:documentation>Defines a port that implements or uses a service that can be implemented with functions or methods.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="structured" type="ipxact:abstractorPortStructuredType">
+					<xs:annotation>
+						<xs:documentation>Represents a port that has subport structure.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element ref="ipxact:arrays" minOccurs="0"/>
+			<xs:element name="access" type="ipxact:portAccessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Port access characteristics.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:parameters" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:simpleType name="initiativeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="requires"/>
+			<xs:enumeration value="provides"/>
+			<xs:enumeration value="both"/>
+			<xs:enumeration value="phantom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="initiative" type="ipxact:initiativeType">
+		<xs:annotation>
+			<xs:documentation>If this element is present, the type of access is restricted to the specified value.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="busWidth" type="ipxact:unsignedIntExpression">
+		<xs:annotation>
+			<xs:documentation>defines the bus size in bits. This can be the result of an expression.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="protocol">
+		<xs:annotation>
+			<xs:documentation>defines the protocol type. Defaults to tlm_base_protocol_type for TLM sockets</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="protocolType">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="ipxact:protocolTypeType">
+								<xs:attribute name="custom" type="xs:string"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:payload" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="protocolTypeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="tlm"/>
+			<xs:enumeration value="custom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="kindType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="tlm_port"/>
+			<xs:enumeration value="tlm_socket"/>
+			<xs:enumeration value="simple_socket"/>
+			<xs:enumeration value="multi_socket"/>
+			<xs:enumeration value="custom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="kind">
+		<xs:annotation>
+			<xs:documentation>Defines the protocol type. Defaults to tlm_base_protocol_type for TLM sockets</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:kindType">
+					<xs:attribute name="custom" type="xs:string"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="simplePortAccessType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ref"/>
+			<xs:enumeration value="ptr"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="portAccessType" type="ipxact:simplePortAccessType">
+		<xs:annotation>
+			<xs:documentation>Indicates how a netlister accesses a port. 'ref' means accessed by reference (default) and 'ptr' means accessed by pointer.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="payload">
+		<xs:annotation>
+			<xs:documentation>defines the structure of data transported by this port</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="name" type="xs:string" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Defines the name of the payload. For example: TLM2 or TLM1</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="type">
+					<xs:annotation>
+						<xs:documentation>Defines the type of the payload. </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="generic"/>
+							<xs:enumeration value="specific"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="extension" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Defines the name of the payload extension. If attribute is not specified, it is by default optional.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="mandatory" type="xs:boolean" use="optional" default="false">
+									<xs:annotation>
+										<xs:documentation>True if the payload extension is mandatory.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="typeParameters">
+		<xs:annotation>
+			<xs:documentation>list of port type parameters (e.g. template or constructor parameters for a systemC port or socket)</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:typeParameter" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="ipxact:serviceTypeDef" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="typeParameterNameUnique">
+			<xs:selector xpath="./ipxact:typeParameter"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="typeParameter" type="ipxact:moduleParameterType">
+		<xs:annotation>
+			<xs:documentation>A typed parameter name value pair. The optional attribute dataType defines the type of the value and the usageType attribute indicates how the parameter is to be used.
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="transTypeDef">
+		<xs:annotation>
+			<xs:documentation>Definition of a single transactional type defintion</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="typeName" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The name of the port type. Can be any predefined type such sc_port or sc_export in SystemC or any user-defined type such as tlm_port.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="exact" type="xs:boolean" default="true">
+									<xs:annotation>
+										<xs:documentation>When false, defines that the type is an abstract type that may not be related to an existing type in the language of the referenced view.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="typeDefinition" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Where the definition of the type is contained. For SystemC and SystemVerilog it is the include file containing the type definition.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:typeParameters" minOccurs="0"/>
+				<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A reference to a view name in the file for which this type applies.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:NMTOKEN">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="serviceTypeDef">
+		<xs:annotation>
+			<xs:documentation>Definition of a single service type defintion</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="typeName">
+					<xs:annotation>
+						<xs:documentation>The name of the service type. Can be any predefined type such as booean or integer or any user-defined type such as addr_type or data_type.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="implicit" type="xs:boolean" default="false">
+									<xs:annotation>
+										<xs:documentation>Defines that the typeName supplied for this service is implicit and a netlister should not declare this service in
+a language specific top-level netlist </xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="typeDefinition" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Where the definition of the type is contained if the type if not part of the language. For SystemC and SystemVerilog it is the include file containing the type definition.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:typeParameters" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="wireTypeDef">
+		<xs:annotation>
+			<xs:documentation>Definition of a single wire type defintion that can relate to multiple views.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="typeName" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The name of the logic type. Examples could be std_logic, std_ulogic, std_logic_vector, sc_logic, ...</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="constrained">
+									<xs:annotation>
+										<xs:documentation>Defines the types for the port has constrained the number of bits in the vector</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:list itemType="xs:Name"/>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="typeDefinition" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Where the definition of the type is contained. For std_logic, this is contained in IEEE.std_logic_1164.all. For sc_logic, this is contained in systemc.h. For VHDL this is the library and package as defined by the "used" statement. For SystemC and SystemVerilog it is the include file required. For verilog this is not needed.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A reference to a view name in the file for which this type applies.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:NMTOKEN">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="wireTypeDefs">
+		<xs:annotation>
+			<xs:documentation>The group of wire type definitions. If no match to a viewName is found then the default language types are to be used. See the User Guide for these default types.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:wireTypeDef" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="wireTypeDefsKey">
+			<xs:selector xpath="ipxact:wireTypeDef/ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="transTypeDefs">
+		<xs:annotation>
+			<xs:documentation>The group of transactional type definitions. If no match to a viewName is found then the default language types are to be used. See the User Guide for these default types.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:transTypeDef" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="transTypeDefsKey">
+			<xs:selector xpath="ipxact:transTypeDef/ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="port">
+		<xs:annotation>
+			<xs:documentation>Describes port characteristics.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ipxact:portType"/>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fieldMap">
+		<xs:annotation>
+			<xs:documentation>Maps slices of this port to component field slices.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="fieldSlice">
+					<xs:annotation>
+						<xs:documentation>Reference to a register field slice</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:group ref="ipxact:fieldSliceReferenceGroup"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:subPortReference" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+				<xs:element name="modeRef" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A reference to a mode.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:Name">
+								<xs:attribute name="priority" type="xs:nonNegativeInteger" use="required"/>
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="fieldMaps">
+		<xs:annotation>
+			<xs:documentation>Listing of maps between component port slices and field slices.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:fieldMap" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="portWireType">
+		<xs:annotation>
+			<xs:documentation>Wire port type for a component.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="direction" type="ipxact:componentPortDirectionType">
+				<xs:annotation>
+					<xs:documentation>The direction of a wire style port. The basic directions for a port are 'in' for input ports, 'out' for output port and 'inout' for bidirectional and tristate ports. 
+A value of 'phantom' is also allowed and define a port that exist on the IP-XACT component but not on the HDL model.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The type of information this port carries a wire port can carry both address and data, but may not mix this with a clock or reset.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vectors" type="ipxact:extendedVectorsType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Vectored information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:wireTypeDefs" minOccurs="0"/>
+			<xs:element ref="ipxact:domainTypeDefs" minOccurs="0"/>
+			<xs:element ref="ipxact:signalTypeDefs" minOccurs="0"/>
+			<xs:element ref="ipxact:drivers" minOccurs="0"/>
+			<xs:element ref="ipxact:constraintSets" minOccurs="0"/>
+			<xs:element name="powerConstraints" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Wire port power constraints.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="powerConstraint" type="ipxact:wirePowerConstraintType" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Single wire port set of power constraints.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="allLogicalDirectionsAllowed" type="xs:boolean" use="optional" default="false">
+			<xs:annotation>
+				<xs:documentation>True if logical ports with different directions from the physical port direction may be mapped onto this port. Forbidden for phantom ports, which always allow logical ports with all direction value to be mapped onto the physical port. Also ignored for inout ports, since any logical port maybe mapped to a physical inout port.            	</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="portTransactionalType">
+		<xs:annotation>
+			<xs:documentation>Transactional port type.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:initiative">
+				<xs:annotation>
+					<xs:documentation>Defines how the port accesses this service.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:kind" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Define the kind of transactional port</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:busWidth" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Defines the bus width in bits.This can be the result of an expression.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The type of information this port carries A transactional port can carry both address and data information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:protocol" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Defines the protocol type. Defaults to tlm_base_protocol_type for TLM sockets</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:transTypeDefs" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Definition of the port type expressed in the default language for this port (i.e. SystemC or SystemV).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="connection" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Bounds number of legal connections.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="maxConnections" type="ipxact:unsignedIntExpression" default="0" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Indicates the maximum number of connections this port supports. If this element is not present or set to 0 it implies an unbounded number of allowed connections.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="minConnections" type="ipxact:unsignedIntExpression" default="1" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Indicates the minimum number of connections this port supports. If this element is not present, the minimum number of allowed connections is 1.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="powerConstraints" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Wire port power constraints.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="powerConstraint" type="ipxact:transactionalPowerConstraintType" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Single wire port set of power constraints.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="allLogicalInitiativesAllowed" type="xs:boolean" use="optional" default="false">
+			<xs:annotation>
+				<xs:documentation>True if logical ports with different initiatives from the physical port initiative may be mapped onto this port. Forbidden for phantom ports, which always allow logical ports with all initiatives value to be mapped onto the physical port. Also ignored for "both" ports, since any logical port may be mapped to a physical "both" port.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="abstractorPortTransactionalType">
+		<xs:annotation>
+			<xs:documentation>Transactional port type.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:initiative">
+				<xs:annotation>
+					<xs:documentation>Defines how the port accesses this service.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:kind" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Define the kind of transactional port</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:busWidth" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Defines the bus width in bits.This can be the result of an expression.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The type of information this port carries A transactional port can carry both address and data information.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:protocol" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Defines the protocol type. Defaults to tlm_base_protocol_type for TLM sockets</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:transTypeDefs" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Definition of the port type expressed in the default language for this port (i.e. SystemC or SystemV).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="connection" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Bounds number of legal connections.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="maxConnections" type="ipxact:unsignedIntExpression" default="0" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Indicates the maximum number of connections this port supports. If this element is not present or set to 0 it implies an unbounded number of allowed connections.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="minConnections" type="ipxact:unsignedIntExpression" default="1" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Indicates the minimum number of connections this port supports. If this element is not present, the minimum number of allowed connections is 1.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="allLogicalInitiativesAllowed" type="xs:boolean" use="optional" default="false">
+			<xs:annotation>
+				<xs:documentation>True if logical ports with different initiatives from the physical port initiative may be mapped onto this port. Forbidden for phantom ports, which always allow logical ports with all initiatives value to be mapped onto the physical port. Also ignored for "both" ports, since any logical port may be mapped to a physical "both" port.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="abstractorPortWireType">
+		<xs:annotation>
+			<xs:documentation>Wire port type for an abstractor.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:restriction base="ipxact:portWireType">
+				<xs:sequence>
+					<xs:element name="direction" type="ipxact:componentPortDirectionType"/>
+					<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>The type of information this port carries a wire port can carry both address and data, but may not mix this with a clock or reset.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="vectors" type="ipxact:extendedVectorsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Vectored information.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="ipxact:wireTypeDefs" minOccurs="0"/>
+					<xs:element ref="ipxact:domainTypeDefs" minOccurs="0"/>
+					<xs:element ref="ipxact:signalTypeDefs" minOccurs="0"/>
+					<xs:element ref="ipxact:drivers" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="extendedVectorsType">
+		<xs:sequence>
+			<xs:element name="vector" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Left and right ranges of the vector.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="ipxact:left"/>
+						<xs:element ref="ipxact:right"/>
+					</xs:sequence>
+					<xs:attribute name="vectorId" type="xs:Name"/>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="portAccessType">
+		<xs:sequence>
+			<xs:element ref="ipxact:portAccessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indicates how a netlister accesses a port. 'ref' means accessed by reference (default) and 'ptr' means accessed through a pointer.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="accessHandles" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence maxOccurs="unbounded">
+						<xs:element name="accessHandle" type="ipxact:portAccessHandle"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="signalTypeDef">
+		<xs:annotation>
+			<xs:documentation>Definition of a single signal type defintion that can relate to multiple views.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="signalType">
+					<xs:annotation>
+						<xs:documentation>defines the signal type for the port. Continuous-conservative is a signal which is continuous in time and quantity, where the quantity represents voltage and current to capture the conservative behavior of an electrical network (i. e. Kirchhoff’s Laws apply), and which has no direction. Continuous-non-conservative is a directed signal which is continuous in time and quantity, where the quantity represents either a voltage or a current (often called signal flow). In this case it only captures the non-conservative behavior of a set of interconnected components. Discrete is a directed sampled signal which is time-discrete and value-continuous (the value may also be quantified), where the value represents either a voltage or a current (other representations are possible also). It captures the non-conservative behavior of a set of interconnected components. Digital is a time-discrete and value-discrete signal. The interpretation of the signal values is described by the wireTypeDefs.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="continuous-conservative"/>
+							<xs:enumeration value="continuous-non-conservative"/>
+							<xs:enumeration value="discrete"/>
+							<xs:enumeration value="digital"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A reference to a view in the file for which this type applies.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:NMTOKEN">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="domainTypeDef">
+		<xs:annotation>
+			<xs:documentation>Definition of a single domain type defintion that can relate to multiple views.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="typeName" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The name of the domain.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="typeDefinition" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Where the definition of the type is contained.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A reference to a view in the file for which this type applies.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:NMTOKEN">
+								<xs:attributeGroup ref="ipxact:id.att"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="domainTypeDefs">
+		<xs:annotation>
+			<xs:documentation>The group of domain type definitions.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:domainTypeDef" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="domainTypeDefsKey">
+			<xs:selector xpath="ipxact:domainTypeDef/ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="signalTypeDefs">
+		<xs:annotation>
+			<xs:documentation>The group of signal type definitions.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:signalTypeDef" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="signalTypeDefsKey">
+			<xs:selector xpath="ipxact:signalTypeDef/ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+	</xs:element>
+	<xs:complexType name="portPacketsType">
+		<xs:sequence>
+			<xs:element name="packet" type="ipxact:portPacketType" minOccurs="1" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="portPacketType">
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="endianness" type="ipxact:endianessType" minOccurs="0"/>
+			<xs:element name="packetFields" type="ipxact:portPacketFieldsType" minOccurs="1"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="portPacketFieldsType">
+		<xs:sequence>
+			<xs:element name="packetField" type="ipxact:portPacketFieldType" minOccurs="1" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="portPacketFieldType">
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroup"/>
+			<xs:element name="width" type="ipxact:unresolvedUnsignedPositiveIntExpression"/>
+			<xs:element name="value" type="ipxact:unsignedBitVectorExpression" minOccurs="0"/>
+			<xs:element name="endianness" type="ipxact:endianessType" minOccurs="0"/>
+			<!-- add a type reference here after PSS 73 -->
+			<xs:element name="qualifier" type="ipxact:qualifierType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The type of information this port carries a wire port can carry both address and data, but may not mix this with a clock or reset.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="arrays">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="array" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Specific left and right array bounds.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element ref="ipxact:left"/>
+							<xs:element ref="ipxact:right"/>
+						</xs:sequence>
+						<xs:attribute name="arrayId" type="xs:Name"/>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="ArrayIdUnique">
+			<xs:selector xpath="ipxact:array"/>
+			<xs:field xpath="@arrayId"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="structPortTypeDefs">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="structPortTypeDef" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="typeName">
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="xs:string">
+											<xs:attribute name="constrained">
+												<xs:annotation>
+													<xs:documentation>Defines the types for the port has constrained the number of bits in the vector</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:list itemType="xs:Name"/>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="typeDefinition" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Where the definition of the type is contained. For SystemC and SystemVerilog it is the include file containing the type definition.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="xs:string">
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="typeParameters" minOccurs="0">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="ipxact:typeParameter" maxOccurs="unbounded"/>
+									</xs:sequence>
+								</xs:complexType>
+								<xs:unique name="structPortTypeDefTypeParameterNameUnique">
+									<xs:selector xpath="./ipxact:typeParameter"/>
+									<xs:field xpath="ipxact:name"/>
+								</xs:unique>
+							</xs:element>
+							<xs:element name="role" type="xs:string" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Indicates the role that this structured port plays in the connection.  Only valid for structured ports with structType='interface'. In SystemVerilog, this indicates the modport for the SystemVerilog interface corresponding to this structuredPortType. </xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>A reference to a view name in the file for which this type applies.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="xs:NMTOKEN">
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="structPortTypeDefTypeNameUnique">
+			<xs:selector xpath="ipxact:structPortTypeDef"/>
+			<xs:field xpath="ipxact:typeName"/>
+		</xs:unique>
+	</xs:element>
+	<xs:complexType name="subPortType">
+		<xs:annotation>
+			<xs:documentation>A port description, giving a name and an access type for high level ports. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupPort"/>
+			<xs:choice>
+				<xs:annotation>
+					<xs:documentation>Port style</xs:documentation>
+				</xs:annotation>
+				<xs:element name="wire" type="ipxact:portWireType">
+					<xs:annotation>
+						<xs:documentation>Defines a port whose type resolves to simple bits.</xs:documentation>
+					</xs:annotation>
+					<xs:unique name="SubPortWireVectorIdUnique">
+						<xs:selector xpath="ipxact:vectors/ipxact:vector"/>
+						<xs:field xpath="@vectorId"/>
+					</xs:unique>
+				</xs:element>
+				<xs:element name="structured" type="ipxact:portStructuredType"/>
+			</xs:choice>
+			<xs:element ref="ipxact:arrays" minOccurs="0"/>
+			<xs:element name="access" type="ipxact:portAccessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Port access characteristics.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attribute name="isIO" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>When present and set to 'true' identifies this port as being an I/O to the containing structure port type.  Only valid for subPorts contained in a structured port with structType='interface'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="abstractorSubPortType">
+		<xs:annotation>
+			<xs:documentation>A port description, giving a name and an access type for high level ports. </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ipxact:nameGroupPort"/>
+			<xs:choice>
+				<xs:annotation>
+					<xs:documentation>Port style</xs:documentation>
+				</xs:annotation>
+				<xs:element name="wire" type="ipxact:abstractorPortWireType">
+					<xs:annotation>
+						<xs:documentation>Defines a port whose type resolves to simple bits.</xs:documentation>
+					</xs:annotation>
+					<xs:unique name="AbstractorSubPortWireVectorIdUnique">
+						<xs:selector xpath="ipxact:vectors/ipxact:vector"/>
+						<xs:field xpath="@vectorId"/>
+					</xs:unique>
+				</xs:element>
+				<xs:element name="structured" type="ipxact:abstractorPortStructuredType"/>
+			</xs:choice>
+			<xs:element ref="ipxact:arrays" minOccurs="0"/>
+			<xs:element name="access" type="ipxact:portAccessType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Port access characteristics.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+		<xs:attribute name="isIO" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>When present and set to 'true' identifies this port as being an I/O to the containing structure port type.  Only valid for subPorts contained in a structured port with structType='interface'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="portStructuredType">
+		<xs:sequence>
+			<xs:group ref="ipxact:structTypeGroup">
+				<xs:annotation>
+					<xs:documentation>Determines the type of structured port.  Can be one of "struct', 'union', or 'interface'.</xs:documentation>
+				</xs:annotation>
+			</xs:group>
+			<xs:element name="vectors" type="ipxact:extendedVectorsType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Vectored information.</xs:documentation>
+				</xs:annotation>
+				<xs:unique name="StructuredPortVectorIdUnique">
+					<xs:selector xpath="ipxact:vector"/>
+					<xs:field xpath="@vectorId"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="subPorts" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="subPort" type="ipxact:subPortType" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+				<xs:unique name="structuredPortUnique">
+					<xs:selector xpath="ipxact:subPort"/>
+					<xs:field xpath="ipxact:name"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element ref="ipxact:structPortTypeDefs"/>
+		</xs:sequence>
+		<xs:attribute name="packed" type="xs:boolean" default="true">
+			<xs:annotation>
+				<xs:documentation>When not present or set to 'true' indicates that this structured port is 'packed'.  If present and set to 'false', indicates that this structured port is 'unpacked'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="abstractorPortStructuredType">
+		<xs:sequence>
+			<xs:group ref="ipxact:structTypeGroup">
+				<xs:annotation>
+					<xs:documentation>Determines the type of structured port.  Can be one of "struct', 'union', or 'interface'.</xs:documentation>
+				</xs:annotation>
+			</xs:group>
+			<xs:element name="vectors" type="ipxact:extendedVectorsType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Vectored information.</xs:documentation>
+				</xs:annotation>
+				<xs:unique name="AbstractStructuredPortVectorIdUnique">
+					<xs:selector xpath="ipxact:vector"/>
+					<xs:field xpath="@vectorId"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="subPorts">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="subPort" type="ipxact:abstractorSubPortType" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+				<xs:unique name="abstractorPortUnique">
+					<xs:selector xpath="ipxact:subPort"/>
+					<xs:field xpath="ipxact:name"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element ref="ipxact:structPortTypeDefs"/>
+		</xs:sequence>
+		<xs:attribute name="packed" type="xs:boolean" default="true">
+			<xs:annotation>
+				<xs:documentation>When not present or set to 'true' indicates that this structured port is 'packed'.  If present and set to 'false', indicates that this structured port is 'unpacked'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="wirePowerConstraintType">
+		<xs:sequence>
+			<xs:element ref="ipxact:powerDomainRef"/>
+			<xs:element ref="ipxact:range" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="transactionalPowerConstraintType">
+		<xs:sequence>
+			<xs:element ref="ipxact:powerDomainRef"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="powerDomainRef" type="xs:Name">
+		<xs:annotation>
+			<xs:documentation>Power domain. It is the user’s responsibility to ensure it matches an existing power domain in UPF/CPF file.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="alwaysOn" type="ipxact:unsignedBitExpression">
+		<xs:annotation>
+			<xs:documentation>Boolean value. If set to true, then the domain/port is always powered, whatever its power domain. Only applies for output ports.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:group name="structTypeGroup">
+		<xs:choice>
+			<xs:element name="struct">
+				<xs:complexType>
+					<xs:attribute name="direction" type="ipxact:componentPortDirectionType">
+						<xs:annotation>
+							<xs:documentation>The direction of a wire style port. The basic directions for a port are 'in' for input ports, 'out' for output port and 'inout' for bidirectional and tristate ports. 
+A value of 'phantom' is also allowed and define a port that exist on the IP-XACT component but not on the HDL model.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="union">
+				<xs:complexType>
+					<xs:attribute name="direction" type="ipxact:componentPortDirectionType">
+						<xs:annotation>
+							<xs:documentation>The direction of a wire style port. The basic directions for a port are 'in' for input ports, 'out' for output port and 'inout' for bidirectional and tristate ports. 
+A value of 'phantom' is also allowed and define a port that exist on the IP-XACT component but not on the HDL model.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="interface">
+				<xs:complexType>
+					<xs:attribute name="phantom" type="xs:boolean"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+</xs:schema>

--- a/ieee-1685-2022/signalDrivers.xsd
+++ b/ieee-1685-2022/signalDrivers.xsd
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:include schemaLocation="autoConfigure.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:element name="defaultValue" type="ipxact:qualifiedExpression">
+		<xs:annotation>
+			<xs:documentation>Default value for a wire port.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="clockDriver">
+		<xs:annotation>
+			<xs:documentation>Describes a driven clock port. </xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ipxact:clockDriverType">
+					<xs:attribute name="clockName" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>Indicates the name of the cllock. If not specified the name is assumed to be the name of the containing port. </xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="singleShotDriver">
+		<xs:annotation>
+			<xs:documentation>Describes a driven one-shot port.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="singleShotOffset">
+					<xs:annotation>
+						<xs:documentation>Time in nanoseconds until start of one-shot.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="ipxact:realExpression">
+								<xs:attribute name="units" type="ipxact:delayValueUnitType" use="optional" default="ns"/>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="singleShotValue">
+					<xs:annotation>
+						<xs:documentation>Value of port after first  edge of one-shot.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="ipxact:unsignedBitVectorExpression"/>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="singleShotDuration">
+					<xs:annotation>
+						<xs:documentation>Duration in nanoseconds of the one shot.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="ipxact:realExpression">
+								<xs:attribute name="units" type="ipxact:delayValueUnitType" use="optional" default="ns"/>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="requiresDriver" default="false">
+		<xs:annotation>
+			<xs:documentation>Specifies if a port requires a driver. Default is false. The attribute driverType can further qualify what type of driver is required. Undefined behaviour if direction is not input or inout. Driver type any indicates that any unspecified type of driver must be connected</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:boolean">
+					<xs:attribute name="driverType" use="optional" default="any">
+						<xs:annotation>
+							<xs:documentation>Defines the type of driver that is required. The default is any type of driver. The 2 other options are a clock type driver or a singleshot type driver.</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:token">
+								<xs:enumeration value="clock"/>
+								<xs:enumeration value="singleShot"/>
+								<xs:enumeration value="any"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="driverType">
+		<xs:annotation>
+			<xs:documentation>Wire port driver type.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence minOccurs="0">
+			<xs:element ref="ipxact:range" minOccurs="0"/>
+			<xs:element name="viewRef" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>A reference to a view in the file for which this type applies.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:NMTOKEN">
+							<xs:attributeGroup ref="ipxact:id.att"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:choice>
+				<xs:element ref="ipxact:defaultValue"/>
+				<xs:element ref="ipxact:clockDriver"/>
+				<xs:element ref="ipxact:singleShotDriver"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="drivers">
+		<xs:annotation>
+			<xs:documentation>Container for wire port driver elements.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:driver" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Wire port driver element. If no range is specified, default value applies to the entire range.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="driver" type="ipxact:driverType">
+		<xs:annotation>
+			<xs:documentation>Wire port driver element.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="clockDriverType">
+		<xs:sequence>
+			<xs:element name="clockPeriod">
+				<xs:annotation>
+					<xs:documentation>Clock period in units defined by the units attribute. Default is nanoseconds.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="ipxact:realExpression">
+							<xs:attribute name="units" type="ipxact:delayValueUnitType" use="optional" default="ns"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="clockPulseOffset">
+				<xs:annotation>
+					<xs:documentation>Time until first pulse. Units are defined by the units attribute. Default is nanoseconds.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="ipxact:realExpression">
+							<xs:attribute name="units" type="ipxact:delayValueUnitType" use="optional" default="ns"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="clockPulseValue" type="ipxact:unsignedBitExpression">
+				<xs:annotation>
+					<xs:documentation>Value of port after first clock edge.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="clockPulseDuration">
+				<xs:annotation>
+					<xs:documentation>Duration of first state in cycle. Units are defined by the units attribute. Default is nanoseconds.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="ipxact:realExpression">
+							<xs:attribute name="units" type="ipxact:delayValueUnitType" use="optional" default="ns"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:element name="otherClockDriver">
+		<xs:annotation>
+			<xs:documentation>Describes a clock not directly associated with an input port. The clockSource attribute can be used on these clocks to indicate the actual clock source (e.g. an output port of a clock generator cell).</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ipxact:clockDriverType">
+					<xs:attribute name="clockName" type="xs:Name" use="required">
+						<xs:annotation>
+							<xs:documentation>Indicates the name of the clock.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="clockSource" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation>Indicates the name of the actual clock source (e.g. an output pin of a clock generator cell).</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/simpleTypes.xsd
+++ b/ieee-1685-2022/simpleTypes.xsd
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="autoConfigure.xsd"/>
+	<xs:complexType name="unsignedLongintExpression">
+		<xs:annotation>
+			<xs:documentation>An unsigned longint which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a unsigend longint value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to an unsigend longint value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unsignedPositiveLongintExpression">
+		<xs:annotation>
+			<xs:documentation>A positive unsigned longint which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a positive unsigned longint value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a positive unsigned longint value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="signedLongintExpression">
+		<xs:annotation>
+			<xs:documentation>An unsigned longint which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a signed longint value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a signed longint value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unsignedIntExpression">
+		<xs:annotation>
+			<xs:documentation>An unsigned int which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to an unsiged int value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a unsigned int value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unsignedPositiveIntExpression">
+		<xs:annotation>
+			<xs:documentation>An positive unsigned int which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to an unsiged int value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a unsigned int value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unresolvedUnsignedPositiveIntExpression">
+		<xs:annotation>
+			<xs:documentation>An positive unsigned int which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to an unsiged int value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a unsigned int value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+	<xs:complexType name="signedIntExpression">
+		<xs:annotation>
+			<xs:documentation>A signed int which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a long value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a long value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+-->
+	<xs:complexType name="realExpression">
+		<xs:annotation>
+			<xs:documentation>A real which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression">
+				<xs:attribute name="minimum" type="xs:double">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a real value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:double">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a real value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unresolvedStringExpression">
+		<xs:annotation>
+			<xs:documentation>Represents a string which cannot be fully resolved.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="stringExpression">
+		<xs:annotation>
+			<xs:documentation>Represents a string. It supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unsignedBitExpression">
+		<xs:annotation>
+			<xs:documentation>Represents a single-bit/bool. It supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="qualifiedExpression">
+		<xs:annotation>
+			<xs:documentation>Represents an expression qualified by an accompanying type. It supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="unsignedBitVectorExpression">
+		<xs:annotation>
+			<xs:documentation>Represents a bit-string. It supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="portName">
+		<xs:annotation>
+			<xs:documentation>A type for a port name string, allows letters, digits, dash, colon, underscore and period</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="\i[\p{L}\p{N}\.\-:_]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="instancePath">
+		<xs:annotation>
+			<xs:documentation>A type for a instance name path string, allows letters, digits, dash, colon, underscore, period and slash</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="\i[\p{L}\p{N}\.\-:_]*"/>
+			<xs:pattern value="\i[\p{L}\p{N}\.\-:_]*/\i[\p{L}\p{N}\.\-:_]*"/>
+			<xs:pattern value="(\i[\p{L}\p{N}\.\-:_]*/)+[\i\p{L}\p{N}\.\-:_]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="complexBaseExpression">
+		<xs:annotation>
+			<xs:documentation>Represents the base-type for an expressions.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:simpleBaseExpression">
+				<xs:attributeGroup ref="ipxact:any.att"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="ipxactURI">
+		<xs:annotation>
+			<xs:documentation>IP-XACT URI, like a standard xs:anyURI except that it can contain environment variables in the ${ } form, to be replaced by their value to provide the underlying URI</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="xs:string"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="simpleUnsignedBitVectorExpression">
+		<xs:annotation>
+			<xs:documentation>Represents a bit-string. It supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="ipxact:simpleBaseExpression"/>
+	</xs:simpleType>
+	<!--
+	<xs:simpleType name="simpleUnsignedBitExpression">
+		<xs:annotation>
+			<xs:documentation>Represents a single-bit/bool. It supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="ipxact:simpleBaseExpression"/>
+	</xs:simpleType>
+-->
+	<xs:simpleType name="simpleUnsignedLongintExpression">
+		<xs:annotation>
+			<xs:documentation>>An unsigned longint which supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="ipxact:simpleBaseExpression"/>
+	</xs:simpleType>
+	<xs:simpleType name="simpleBaseExpression">
+		<xs:annotation>
+			<xs:documentation>Represents the base-type for an expressions.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="unresolvedUnsignedBitExpression">
+		<xs:annotation>
+			<xs:documentation>Unsigned Bit Expression which cannot be fully resolved.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:complexBaseExpression"/>
+		</xs:simpleContent>
+	</xs:complexType>
+</xs:schema>

--- a/ieee-1685-2022/subInstances.xsd
+++ b/ieee-1685-2022/subInstances.xsd
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="simpleTypes.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="autoConfigure.xsd"/>
+	<xs:complexType name="complexTiedValueExpression">
+		<xs:annotation>
+			<xs:documentation>An unsigned bit vector expression that resolves to the value set {0, 1, ...} or or the string values 'open' or 'default'.  It is derived from simpleUnsignedBitVectorExpression and it supports an expression value.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="ipxact:simpleUnsignedBitVectorExpression">
+				<xs:attributeGroup ref="ipxact:any.att"/>
+				<xs:attribute name="minimum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a long value, this indicates the minimum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="maximum" type="xs:int">
+					<xs:annotation>
+						<xs:documentation>For elements which can be specified using expression which are supposed to be resolved to a long value, this indicates the maximum value allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:element name="configurableElementValues">
+		<xs:annotation>
+			<xs:documentation>All configuration information for a contained component, generator, generator chain or abstractor instance.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence maxOccurs="unbounded">
+				<xs:element ref="ipxact:configurableElementValue">
+					<xs:annotation>
+						<xs:documentation>Describes the content of a configurable element. The required referenceId attribute refers to the ID attribute of the configurable element.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="configurableElementValueReferenceUnique">
+			<xs:selector xpath="ipxact:configurableElementValue"/>
+			<xs:field xpath="@referenceId"/>
+		</xs:unique>
+	</xs:element>
+	<xs:element name="configurableElementValue">
+		<xs:annotation>
+			<xs:documentation>Describes the content of a configurable element. The required referenceId attribute refers to the ID attribute of the configurable element.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="ipxact:complexBaseExpression">
+					<xs:attribute name="referenceId" type="xs:Name" use="required">
+						<xs:annotation>
+							<xs:documentation>Refers to the ID attribute of the configurable element.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attributeGroup ref="ipxact:id.att"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="instanceName" type="xs:Name">
+		<xs:annotation>
+			<xs:documentation>An instance name assigned to subcomponent instances and contained channels, that is unique within the parent component.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="componentInstance">
+		<xs:annotation>
+			<xs:documentation>Component instance element.  The instance name is contained in the unique-value instanceName attribute.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:instanceName"/>
+				<xs:element ref="ipxact:displayName" minOccurs="0"/>
+				<xs:element ref="ipxact:shortDescription" minOccurs="0"/>
+				<xs:element ref="ipxact:description" minOccurs="0"/>
+				<xs:element name="componentRef" type="ipxact:configurableLibraryRefType">
+					<xs:annotation>
+						<xs:documentation>References a component to be found in an external library.  The four attributes define the VLNV of the referenced element.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:powerDomainLinks" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="componentInstances">
+		<xs:annotation>
+			<xs:documentation>Sub instances of internal components.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:componentInstance" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="adHocConnection">
+		<xs:annotation>
+			<xs:documentation>Represents an ad-hoc connection between component ports.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroupPort"/>
+				<xs:element name="tiedValue" type="ipxact:complexTiedValueExpression" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The logic value of this connection. The value can be an unsigned bit vector expression or the string values 'open' or 'default'. Only valid for ports of style wire.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="portReferences">
+					<xs:annotation>
+						<xs:documentation>Liist of internal and external port references involved in the adhocConnection</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:choice>
+							<xs:sequence>
+								<xs:element name="internalPortReference" maxOccurs="unbounded">
+									<xs:annotation>
+										<xs:documentation>Defines a reference to a port on a component contained within the design.</xs:documentation>
+									</xs:annotation>
+									<xs:complexType>
+										<xs:sequence>
+											<xs:element ref="ipxact:subPortReference" minOccurs="0" maxOccurs="unbounded"/>
+											<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+											<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+										</xs:sequence>
+										<xs:attribute name="portRef" type="ipxact:portName" use="required">
+											<xs:annotation>
+												<xs:documentation>A port on the on the referenced component from componentInterfaceRef.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="componentInstanceRef" type="xs:Name" use="required">
+											<xs:annotation>
+												<xs:documentation>A reference to the instanceName element of a component in this design.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attributeGroup ref="ipxact:id.att"/>
+									</xs:complexType>
+								</xs:element>
+								<xs:element ref="ipxact:externalPortReference" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+							<xs:element ref="ipxact:externalPortReference" maxOccurs="unbounded"/>
+						</xs:choice>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="adHocConnections">
+		<xs:annotation>
+			<xs:documentation>Defines the set of ad-hoc connections in a design. An ad-hoc connection represents a connection between two component pins which were not connected as a result of interface connections (i.e.the pin to pin connection was made explicitly and is represented explicitly).</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:adHocConnection" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="interconnection">
+		<xs:annotation>
+			<xs:documentation>Describes a connection between two active (not monitor) busInterfaces.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroup"/>
+				<xs:element ref="ipxact:activeInterface">
+					<xs:annotation>
+						<xs:documentation>Describes one interface of the interconnection.
+
+The componentInterfaceRef and busRef attributes indicate the instance name and bus interface name of one end of the connection.                                                  This interface can be connected to one or more additional active and/or hierarchical interfaces, or to one or more hierarchical interfaces or to one or more monitor interfaces. The connected interfaces are all contained within the choice element below.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:choice>
+					<xs:sequence>
+						<xs:element ref="ipxact:activeInterface" maxOccurs="unbounded"/>
+						<xs:element name="hierInterface" type="ipxact:hierInterfaceType" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:element name="hierInterface" type="ipxact:hierInterfaceType" maxOccurs="unbounded"/>
+				</xs:choice>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="monitorInterconnection">
+		<xs:annotation>
+			<xs:documentation>Describes a connection from the interface of one component to any number of monitor interfaces in the design.
+
+An active interface can be connected to unlimited number of monitor interfaces.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="ipxact:nameGroup"/>
+				<xs:element name="monitoredActiveInterface" type="ipxact:monitorInterfaceType">
+					<xs:annotation>
+						<xs:documentation>Describes an active interface of the design that all the monitors will be connected to.
+
+The componentInterfaceRef and busRef attributes indicate the instance name and bus interface name. The optional path attribute indicates the hierarchical instance name path to the component.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="monitorInterface" type="ipxact:monitorInterfaceType" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Describes a list of monitor interfaces that are connected to the single active interface.
+
+The componentInterfaceRef and busRef attributes indicate the instance name and bus interface name. The optional path attribute indicates the hierarchical instance name path to the component.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="interconnections">
+		<xs:annotation>
+			<xs:documentation>Connections between internal sub components.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="ipxact:interconnection"/>
+				<xs:element ref="ipxact:monitorInterconnection"/>
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="interfaceType">
+		<xs:annotation>
+			<xs:documentation>A representation of a component/bus interface relation; i.e. a bus interface belonging to a certain component.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="componentInstanceRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to a component instance name.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="busRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to the components  bus interface</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="hierInterfaceType">
+		<xs:annotation>
+			<xs:documentation>A representation of an exported interface. The busRef indicates the name of the interface in the containing component.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element ref="ipxact:description" minOccurs="0"/>
+			<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="busRef" type="xs:Name" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to the components  bus interface</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ipxact:id.att"/>
+	</xs:complexType>
+	<xs:complexType name="monitorInterfaceType">
+		<xs:annotation>
+			<xs:documentation>Hierarchical reference to an interface being monitored or monitoring another interface.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="ipxact:interfaceType">
+				<xs:sequence>
+					<xs:element ref="ipxact:description" minOccurs="0"/>
+					<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+				</xs:sequence>
+				<xs:attribute name="path" type="ipxact:instancePath">
+					<xs:annotation>
+						<xs:documentation>A decending hierarchical (slash separated - example x/y/z) path to the component instance containing the specified component instance in componentInterfaceRef. If not specified the componentInterfaceRef instance shall exist in the current design. </xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="externalPortReference">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ipxact:subPortReference" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="ipxact:partSelect" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="portRef" type="ipxact:portName" use="required">
+				<xs:annotation>
+					<xs:documentation>A port on the on the referenced component from componentInterfaceRef.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="activeInterface">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ipxact:interfaceType">
+					<xs:sequence>
+						<xs:element ref="ipxact:description" minOccurs="0"/>
+						<xs:element name="excludePorts" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The list of physical ports to be excluded from an interface based connection. Analogous to the removing the port map element for the named ports.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="excludePort" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>The name of a physical port to be excluded from the interface based connection.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="ipxact:portName">
+													<xs:attributeGroup ref="ipxact:id.att"/>
+												</xs:extension>
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="powerDomainLinks">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="powerDomainLink" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>A power domain link to one external power domain and one or more internal power domains.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="externalPowerDomainReference" type="ipxact:stringExpression">
+								<xs:annotation>
+									<xs:documentation>Reference to a power domain defined on the top component.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="internalPowerDomainReference" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Reference to a power domain defined on an instance</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:simpleContent>
+										<xs:extension base="xs:Name">
+											<xs:attributeGroup ref="ipxact:id.att"/>
+										</xs:extension>
+									</xs:simpleContent>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attributeGroup ref="ipxact:id.att"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+		<xs:unique name="componentInstanceInternalPowerDomainReferenceUnique">
+			<xs:selector xpath="ipxact:powerDomainLink/ipxact:internalPowerDomainReference"/>
+			<xs:field xpath="."/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/typeDefinitions.xsd
+++ b/ieee-1685-2022/typeDefinitions.xsd
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.accellera.org/XMLSchema/IPXACT/1685-2022" elementFormDefault="qualified">
+	<xs:include schemaLocation="identifier.xsd"/>
+	<xs:include schemaLocation="commonStructures.xsd"/>
+	<xs:include schemaLocation="constraints.xsd"/>
+	<xs:include schemaLocation="memoryMap.xsd"/>
+	<xs:element name="typeDefinitions">
+		<xs:complexType>
+			<xs:sequence minOccurs="0">
+				<xs:group ref="ipxact:documentNameGroup"/>
+				<xs:element ref="ipxact:externalTypeDefinitions" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="modes" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A list of user defined component modes.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="mode" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:group ref="ipxact:nameGroup"/>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="views" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A list of user defined views.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="view" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:group ref="ipxact:nameGroup"/>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:fieldAccessPolicyDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:enumerationDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:fieldDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:registerDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:registerFileDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:addressBlockDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:bankDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:memoryMapDefinitions" minOccurs="0"/>
+				<xs:element ref="ipxact:memoryRemapDefinitions" minOccurs="0"/>
+				<xs:element name="resetTypes" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>A list of user defined resetTypes applicable to this component.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="resetType" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>A user defined reset policy</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:group ref="ipxact:nameGroup"/>
+										<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attributeGroup ref="ipxact:id.att"/>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ipxact:choices" minOccurs="0"/>
+				<xs:element ref="ipxact:parameters" minOccurs="0"/>
+				<xs:element ref="ipxact:assertions" minOccurs="0"/>
+				<xs:element ref="ipxact:vendorExtensions" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attributeGroup ref="ipxact:id.att"/>
+		</xs:complexType>
+		<xs:key name="typeDefinitionsChoiceKey">
+			<xs:selector xpath="ipxact:choices/ipxact:choice"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="typeDefinitionsChoiceRef" refer="ipxact:typeDefinitionsChoiceKey">
+			<xs:selector xpath=".//ipxact:parameter | .//ipxact:moduleParameter"/>
+			<xs:field xpath="@choiceRef"/>
+		</xs:keyref>
+		<xs:key name="typeDefinitionsResetTypeKey">
+			<xs:selector xpath="ipxact:resetTypes/ipxact:resetType"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="typeDefinitionsFieldResetTypeRef" refer="ipxact:typeDefinitionsResetTypeKey">
+			<xs:selector xpath=".//ipxact:field/ipxact:resets/ipxact:reset  | .//ipxact:ports/ipxact:port/ipxact:isReset"/>
+			<xs:field xpath="@resetTypeRef"/>
+		</xs:keyref>
+		<xs:keyref name="typeDefinitionsFieldDefinitionResetTypeRef" refer="ipxact:typeDefinitionsResetTypeKey">
+			<xs:selector xpath=".//ipxact:fieldDefinition/ipxact:resets/ipxact:reset  | .//ipxact:ports/ipxact:port/ipxact:isReset"/>
+			<xs:field xpath="@resetTypeRef"/>
+		</xs:keyref>
+		<xs:keyref name="typeDefinitionsResetTypeLinkResetTypeRef" refer="ipxact:typeDefinitionsResetTypeKey">
+			<xs:selector xpath=".//ipxact:resetTypeLink/ipxact:resetTypeReference"/>
+			<xs:field xpath="@resetTypeRef"/>
+		</xs:keyref>
+		<xs:unique name="typeDefinitionsParameterUnique">
+			<xs:selector xpath=".//ipxact:parameter | .//ipxact:moduleParameter"/>
+			<xs:field xpath="@parameterId"/>
+		</xs:unique>
+		<xs:key name="typeDefinitionsMemoryRemapDefinitionKey">
+			<xs:selector xpath="ipxact:memoryRemapDefinitions/ipxact:memoryRemapDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsMemoryMapDefinitionKey">
+			<xs:selector xpath="ipxact:memoryMapDefinitions/ipxact:memoryMapDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsBankDefinitionKey">
+			<xs:selector xpath="ipxact:bankDefinitions/ipxact:bankDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsAddressBlockDefinitionKey">
+			<xs:selector xpath="ipxact:addressBlockDefinitions/ipxact:addressBlockDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsRegisterFileDefinitionKey">
+			<xs:selector xpath="ipxact:registerFileDefinitions/ipxact:registerFileDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsRegisterDefinitionKey">
+			<xs:selector xpath="ipxact:registerDefinitions/ipxact:registerDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsFieldDefinitionKey">
+			<xs:selector xpath="ipxact:fieldDefinitions/ipxact:fieldDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsEnumerationDefinitionKey">
+			<xs:selector xpath="ipxact:enumerationDefinitions/ipxact:enumerationDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsFieldAccessPolicyDefinitionKey">
+			<xs:selector xpath="ipxact:fieldAccessPolicyDefinitions/ipxact:fieldAccessPolicyDefinition"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:key name="typeDefinitionsViewKey">
+			<xs:selector xpath="ipxact:views/ipxact:view"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="typeDefinitionsViewLinkViewRef" refer="ipxact:typeDefinitionsViewKey">
+			<xs:selector xpath=".//ipxact:viewLink/ipxact:viewReference"/>
+			<xs:field xpath="@viewRef"/>
+		</xs:keyref>
+		<xs:keyref name="typeDefinitionsViewRef" refer="ipxact:typeDefinitionsViewKey">
+			<xs:selector xpath=".//ipxact:viewRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:key name="typeDefinitionsModeKey">
+			<xs:selector xpath="ipxact:modes/ipxact:mode"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="typeDefinitionsModeLinkModeRef" refer="ipxact:typeDefinitionsModeKey">
+			<xs:selector xpath=".//ipxact:modeLink/ipxact:modeReference"/>
+			<xs:field xpath="@modeRef"/>
+		</xs:keyref>
+		<xs:keyref name="typeDefinitionsModeRef" refer="ipxact:typeDefinitionsModeKey">
+			<xs:selector xpath=".//ipxact:modeRef"/>
+			<xs:field xpath="."/>
+		</xs:keyref>
+		<xs:key name="typeDefinitionsExternalTypeDefinitionsKey">
+			<xs:selector xpath="ipxact:externalTypeDefinitions"/>
+			<xs:field xpath="ipxact:name"/>
+		</xs:key>
+		<xs:keyref name="typeDefinitionsExternalTypeDefinitionsRef" refer="ipxact:typeDefinitionsExternalTypeDefinitionsKey">
+			<xs:selector xpath=".//ipxact:*"/>
+			<xs:field xpath="@typeDefinitions"/>
+		</xs:keyref>
+	</xs:element>
+</xs:schema>

--- a/ieee-1685-2022/xml.xsd
+++ b/ieee-1685-2022/xml.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.w3.org/XML/1998/namespace">
+    <xs:attribute name="id" type="xs:ID">
+      <xs:annotation>
+        <xs:documentation>A generic mechanism for annotating elements with unique identifiers. See: http://www.w3.org/TR/xml-id/ for more information.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+</xs:schema>


### PR DESCRIPTION
# New Features

* Added IEEE Std. 1685-2022 as suggested by @ejd.
* Added Apache License 2.0 license and notice files.


# Changes

* Updated main README.
  * Added links to original sources.
  * Added license information.
* Moves notes by Accellera into version specific README files.
  * ⚠️ The README (written by Accellera) provides contradicting rules compared to the LICENSE file.

# Related PRs and Issues

* Fixes #1.